### PR TITLE
Refactor/layer 2 auth 2

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -47,7 +47,11 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     },
   },
   session: {
-    maxAge: 24 * 60 * 60, // 24 hours — replaces the hasExpired() date-change hack (Layer 3)
+    // 24 hours from login time. Note: the previous hasExpired() implementation expired
+    // sessions at midnight (when the calendar date changed), not after a fixed duration.
+    // This is intentionally stricter — a session created at 11:55pm now lasts until 11:55pm
+    // the next day rather than expiring 5 minutes later.
+    maxAge: 24 * 60 * 60,
   },
   pages: {
     signIn: '/login',

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -46,6 +46,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       return session
     },
   },
+  session: {
+    maxAge: 24 * 60 * 60, // 24 hours — replaces the hasExpired() date-change hack (Layer 3)
+  },
   pages: {
     signIn: '/login',
   },

--- a/src/store/actions/authActions.ts
+++ b/src/store/actions/authActions.ts
@@ -4,6 +4,10 @@ import { ISODateString } from '@/types/isoDateType'
 type AuthAction = { type: 'AUTH' }
 type UnauthAction = { type: 'UNAUTH' }
 
+/**
+ * @deprecated next-auth manages the session token. Use `signIn()` from next-auth/react instead.
+ * Full removal in Layer 3.
+ */
 export function setAuthToken({ token, user }: { token: string; user: IUser }): AuthAction {
   sessionStorage.setItem('user_token', token)
   const today = new Date(Date.now()).toLocaleDateString('en-US', {
@@ -16,6 +20,10 @@ export function setAuthToken({ token, user }: { token: string; user: IUser }): A
   }
 }
 
+/**
+ * @deprecated next-auth manages session cleanup. Use `signOut()` from next-auth/react instead.
+ * Full removal in Layer 3.
+ */
 export function removeAuthToken(): UnauthAction {
   sessionStorage.removeItem('user_token')
   sessionStorage.removeItem('user_data')
@@ -25,6 +33,9 @@ export function removeAuthToken(): UnauthAction {
   }
 }
 
+/**
+ * @deprecated Route protection handled by next-auth middleware. Full removal in Layer 3.
+ */
 export function hasToken(): AuthAction | UnauthAction {
   const hasToken = sessionStorage.getItem('user_token') !== null
   if (hasToken) {
@@ -38,6 +49,9 @@ export function hasToken(): AuthAction | UnauthAction {
   }
 }
 
+/**
+ * @deprecated Session expiry handled by next-auth `maxAge`. Full removal in Layer 3.
+ */
 export function hasExpired(): AuthAction | UnauthAction {
   const createdOn = sessionStorage.getItem('created_on')
   const today = new Date(Date.now()).toLocaleDateString('en-US', {

--- a/src/store/actions/userActions.ts
+++ b/src/store/actions/userActions.ts
@@ -4,6 +4,9 @@ import { IUser } from '@/types/IUser'
 
 type EditAction = { type: 'EDIT'; editProps: Record<string, unknown>[] }
 
+/**
+ * @deprecated User data will come from next-auth session via `useSession()`. Full removal in Layer 3.
+ */
 export function populateUser(): { type: 'POPULATE'; allData: IUser } {
   return {
     type: 'POPULATE',

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -2,5 +2,14 @@
 import { useDispatch, useSelector } from 'react-redux'
 import type { AppDispatch, RootState } from './store'
 
+/**
+ * @deprecated Redux removed in Layer 3. Use `useSession()` from next-auth/react
+ * or React Query for server state instead.
+ */
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>()
+
+/**
+ * @deprecated Redux removed in Layer 3. Use `useSession()` from next-auth/react
+ * or React Query for server state instead.
+ */
 export const useAppSelector = useSelector.withTypes<RootState>()

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -9,6 +9,8 @@ const store = configureStore({
   },
 })
 
+/** @deprecated Redux removed in Layer 3. */
 export type RootState = ReturnType<typeof store.getState>
+/** @deprecated Redux removed in Layer 3. */
 export type AppDispatch = typeof store.dispatch
 export default store


### PR DESCRIPTION
## Summary by Sourcery

Deprecate legacy Redux-based auth and user session helpers in favor of next-auth and configure next-auth session expiry.

Enhancements:
- Add next-auth session maxAge configuration to replace custom date-based expiry logic.

Chores:
- Mark legacy auth token, route protection, session expiry, and user population Redux actions as deprecated pending removal in a later layer.