### PR TITLE
Refactor layer 4 forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.0.18",
+        "@hookform/resolvers": "^5.2.2",
         "@tailwindcss/postcss": "^4.2.1",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-query-devtools": "^5.91.3",
@@ -24,8 +25,10 @@
         "next-auth": "^5.0.0-beta.30",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-hook-form": "^7.71.2",
         "tailwindcss": "^4.2.1",
-        "ts-node": "^10.9.1"
+        "ts-node": "^10.9.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
@@ -887,6 +890,17 @@
       "integrity": "sha512-7TyMjRrZZMBPa+/5Y8lN0iyvUU/01PeMGX2+RE7cQWpEUIcb4QotzUObFkJDejj/HUH4qjP/eQ0gzzKs2f+6Yw==",
       "peerDependencies": {
         "react": ">= 16"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2156,6 +2170,11 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -10210,6 +10229,21 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.71.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
+      "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "test": "cross-env TZ=EST jest",
     "test:ui": "cross-env CYPRESS_ENV=development cypress run --browser chrome",
@@ -18,6 +19,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.0.18",
+    "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/postcss": "^4.2.1",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",
@@ -32,8 +34,10 @@
     "next-auth": "^5.0.0-beta.30",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-hook-form": "^7.71.2",
     "tailwindcss": "^4.2.1",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",

--- a/src/app/login/components/login-form.tsx
+++ b/src/app/login/components/login-form.tsx
@@ -1,34 +1,35 @@
-import { FormEvent } from 'react'
+import { UseFormRegister, FieldErrors } from 'react-hook-form'
+import { LoginFormData } from '@/lib/schemas/auth.schemas'
 
 export default function LoginForm({
-  handleInput,
-  formData,
-  isLoading,
-  submitForm,
+  register,
+  errors,
+  isSubmitting,
+  onSubmit,
+  onFieldChange,
 }: {
-  handleInput: (e: React.FormEvent<HTMLInputElement>) => void
-  formData: { email: string; password: string }
-  isLoading: boolean
-  submitForm: (e: FormEvent<HTMLFormElement>) => Promise<void>
+  register: UseFormRegister<LoginFormData>
+  errors: FieldErrors<LoginFormData>
+  isSubmitting: boolean
+  onSubmit: () => void
+  onFieldChange: () => void
 }) {
   return (
     <>
-      <form data-testid="login-form" className="space-y-6" onSubmit={submitForm} method="POST">
+      <form data-testid="login-form" className="space-y-6" onSubmit={onSubmit} method="POST">
         <div>
           <label htmlFor="email" className="block text-sm font-medium leading-6 text-gray-900">
             Email:
           </label>
           <div className="mt-2">
             <input
-              onChange={handleInput}
-              value={formData.email}
+              {...register('email', { onChange: onFieldChange })}
               id="email"
-              name="email"
               type="text"
               autoComplete="email"
-              required
               className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
             />
+            {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
           </div>
         </div>
 
@@ -45,15 +46,13 @@ export default function LoginForm({
           </div>
           <div className="mt-2">
             <input
-              onChange={handleInput}
-              value={formData.password}
+              {...register('password', { onChange: onFieldChange })}
               id="password"
-              name="password"
               type="password"
               autoComplete="current-password"
-              required
               className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
             />
+            {errors.password && <p className="text-red-500 text-sm">{errors.password.message}</p>}
           </div>
         </div>
 
@@ -61,10 +60,10 @@ export default function LoginForm({
           <button
             data-testid="login-button"
             type="submit"
-            disabled={isLoading}
+            disabled={isSubmitting}
             className="default-btn flex w-full justify-center"
           >
-            {isLoading ? 'Loading...' : 'Sign In'}
+            {isSubmitting ? 'Loading...' : 'Sign In'}
           </button>
         </div>
       </form>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,50 +1,42 @@
 'use client'
 
 import LoginForm from '@/app/login/components/login-form'
-import React, { useState, FormEvent } from 'react'
+import React, { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { signIn, getSession } from 'next-auth/react'
 import Link from 'next/link'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { loginSchema, LoginFormData } from '@/lib/schemas/auth.schemas'
 
 export default function Login() {
   const router = useRouter()
 
-  const [formData, setFormData] = useState<{ email: string; password: string }>({
-    email: '',
-    password: '',
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginFormData>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: '', password: '' },
   })
 
-  const [isLoading, setIsLoading] = useState<boolean>(false)
   const [formSubmitOutcomeMessage, setFormSubmitOutcomeMessage] = useState('')
 
-  function handleInput(e: React.FormEvent<HTMLInputElement>) {
+  function clearMessage() {
     if (formSubmitOutcomeMessage.length) {
       setFormSubmitOutcomeMessage('')
     }
-
-    const target = e.target as HTMLInputElement
-    setFormData((prevState) => ({
-      ...prevState,
-      [target.name]: target.value,
-    }))
   }
 
-  async function submitForm(e: FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    setIsLoading(true)
-
-    const rawFormData = new FormData(e.currentTarget)
-    const email = rawFormData.get('email') as string
-    const password = rawFormData.get('password') as string
-
+  async function submitForm(data: LoginFormData) {
     try {
       const result = await signIn('credentials', {
-        userId: btoa(email),
-        password,
+        userId: btoa(data.email),
+        password: data.password,
         redirect: false,
       })
-
-      setIsLoading(false)
 
       if (result?.error) {
         setFormSubmitOutcomeMessage(
@@ -55,7 +47,7 @@ export default function Login() {
         return
       }
 
-      setFormData({ email: '', password: '' })
+      reset()
       setFormSubmitOutcomeMessage('Logging in ...')
 
       const session = await getSession()
@@ -68,9 +60,10 @@ export default function Login() {
         return
       }
 
+      // Full navigation needed to reload auth session — router.push won't suffice
+      // eslint-disable-next-line react-hooks/immutability
       window.location.href = '/' + username
     } catch {
-      setIsLoading(false)
       setFormSubmitOutcomeMessage(
         'Failed to login due to an internal error. Please try again later.'
       )
@@ -86,7 +79,13 @@ export default function Login() {
       </div>
 
       <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
-        <LoginForm {...{ handleInput, formData, isLoading, submitForm }} />
+        <LoginForm
+          register={register}
+          errors={errors}
+          isSubmitting={isSubmitting}
+          onSubmit={handleSubmit(submitForm)}
+          onFieldChange={clearMessage}
+        />
         <div className="mt-3 text-center">{formSubmitOutcomeMessage}</div>
 
         <p className="mt-10 text-center text-sm text-gray-500">

--- a/src/app/register/components/register-form.tsx
+++ b/src/app/register/components/register-form.tsx
@@ -1,35 +1,35 @@
-import { FormEvent } from 'react'
-import { IUserFormData } from '../../../types/IUser'
+import { UseFormRegister, FieldErrors } from 'react-hook-form'
+import { RegisterFormData } from '@/lib/schemas/auth.schemas'
 
 export default function RegisterForm({
-  handleInput,
-  formData,
-  isLoading,
-  submitForm,
+  register,
+  errors,
+  isSubmitting,
+  onSubmit,
+  onFieldChange,
 }: {
-  handleInput: (e: React.FormEvent<HTMLInputElement>) => void
-  formData: IUserFormData
-  isLoading: boolean
-  submitForm: (e: FormEvent<HTMLFormElement>) => void
+  register: UseFormRegister<RegisterFormData>
+  errors: FieldErrors<RegisterFormData>
+  isSubmitting: boolean
+  onSubmit: () => void
+  onFieldChange: () => void
 }) {
   return (
     <>
-      <form data-testid="register-form" className="space-y-6" onSubmit={submitForm} method="POST">
+      <form data-testid="register-form" className="space-y-6" onSubmit={onSubmit} method="POST">
         <div>
           <label htmlFor="firstName" className="block text-sm font-medium leading-6 text-gray-900">
             First Name:
           </label>
           <div className="mt-2">
             <input
-              onChange={handleInput}
-              value={formData.firstName}
+              {...register('firstName', { onChange: onFieldChange })}
               id="firstName"
-              name="firstName"
               type="text"
               autoComplete="firstName"
-              required
               className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
             />
+            {errors.firstName && <p className="text-red-500 text-sm">{errors.firstName.message}</p>}
           </div>
         </div>
         <div>
@@ -38,15 +38,13 @@ export default function RegisterForm({
           </label>
           <div className="mt-2">
             <input
-              onChange={handleInput}
-              value={formData.lastName}
+              {...register('lastName', { onChange: onFieldChange })}
               id="lastName"
-              name="lastName"
               type="text"
               autoComplete="lastName"
-              required
               className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
             />
+            {errors.lastName && <p className="text-red-500 text-sm">{errors.lastName.message}</p>}
           </div>
         </div>
         <div>
@@ -55,15 +53,13 @@ export default function RegisterForm({
           </label>
           <div className="mt-2">
             <input
-              onChange={handleInput}
-              value={formData.password}
+              {...register('password', { onChange: onFieldChange })}
               id="password"
-              name="password"
               type="password"
               autoComplete="password"
-              required
               className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
             />
+            {errors.password && <p className="text-red-500 text-sm">{errors.password.message}</p>}
           </div>
         </div>
         <div>
@@ -72,26 +68,30 @@ export default function RegisterForm({
           </label>
           <div className="mt-2">
             <input
-              onChange={handleInput}
-              value={formData.email}
+              {...register('email', { onChange: onFieldChange })}
               id="email"
-              name="email"
               type="email"
               autoComplete="email"
-              required
               className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
             />
+            {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
           </div>
         </div>
         <fieldset>
           <legend>Account Type:</legend>
           <div>
-            <input type="radio" id="student" name="accountType" value="student" defaultChecked />
+            <input
+              {...register('accountType')}
+              type="radio"
+              id="student"
+              value="student"
+              defaultChecked
+            />
             <label htmlFor="student">Student</label>
           </div>
 
           <div>
-            <input type="radio" id="teacher" name="accountType" value="teacher" />
+            <input {...register('accountType')} type="radio" id="teacher" value="teacher" />
             <label htmlFor="teacher">Teacher</label>
           </div>
         </fieldset>
@@ -99,10 +99,10 @@ export default function RegisterForm({
         <div>
           <button
             type="submit"
-            disabled={isLoading}
+            disabled={isSubmitting}
             className="flex w-full justify-center default-btn"
           >
-            {isLoading ? 'Loading...' : 'Create Account'}
+            {isSubmitting ? 'Loading...' : 'Create Account'}
           </button>
         </div>
       </form>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,75 +1,55 @@
 'use client'
 
-import React, { useState, FormEvent } from 'react'
+import React, { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import RegisterForm from '@/app/register/components/register-form'
-import { IUser, IUserFormData } from '@/types/IUser'
+import { IUser } from '@/types/IUser'
 import { IResponse } from '@/types/IApiResponse'
 import { registerUser } from '@/api/controller'
 import { ISODateString } from '@/types/isoDateType'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { registerSchema, RegisterFormData } from '@/lib/schemas/auth.schemas'
 
-interface IRegister {
-  handleInput: (e: React.FormEvent<HTMLInputElement>) => void
-  submitForm: (e: FormEvent<HTMLFormElement>) => Promise<void>
-}
-
-export default function Register<IRegister>() {
+export default function Register() {
   const router = useRouter()
 
-  const [formData, setFormData] = useState<IUserFormData>({
-    firstName: '',
-    lastName: '',
-    email: '',
-    password: '',
-    accountType: '',
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<RegisterFormData>({
+    resolver: zodResolver(registerSchema),
+    defaultValues: {
+      firstName: '',
+      lastName: '',
+      email: '',
+      password: '',
+      accountType: 'student',
+    },
   })
 
-  const [isLoading, setIsLoading] = useState(false)
   const [formSubmitOutcomeMessage, setFormSubmitOutcomeMessage] = useState('')
 
-  function handleInput(e: React.FormEvent<HTMLInputElement>) {
+  function clearMessage() {
     if (formSubmitOutcomeMessage.length) {
       setFormSubmitOutcomeMessage('')
     }
-
-    const target = e.target as HTMLInputElement
-    const fieldName = target.name
-    const fieldValue = target.value
-
-    setFormData((prevState) => ({
-      ...prevState,
-      [fieldName]: fieldValue,
-    }))
   }
 
-  async function submitForm(e: FormEvent<HTMLFormElement>) {
+  async function submitForm(data: RegisterFormData) {
     try {
-      // We don't want the page to refresh
-      e.preventDefault()
-      setIsLoading(true) // Set loading to true when the request starts
-
-      const rawFormData = new FormData(e.currentTarget)
-      const jsonData: IUserFormData = {
-        firstName: '',
-        lastName: '',
-        email: '',
-        password: '',
-        accountType: '',
-      }
-
-      for (const pair of rawFormData.entries()) {
-        ;(jsonData as Record<string, string>)[pair[0].trim()] = `${(pair[1] as string).trim()}`
-      }
-
-      const userId = btoa(jsonData.email)
-      const username = `${jsonData.firstName}-${jsonData.lastName}`
-      const linkedAccountsData = jsonData.accountType === 'teacher' ? { students: [] } : {}
+      const userId = btoa(data.email)
+      const username = `${data.firstName}-${data.lastName}`
+      const linkedAccountsData = data.accountType === 'teacher' ? { students: [] } : {}
+      const now = new Date()
 
       const userData: IUser = {
-        ...jsonData,
+        ...data,
         userId,
         username,
-        lastLogin: new Date(Date.now()).toLocaleDateString('en-US', {
+        lastLogin: now.toLocaleDateString('en-US', {
           timeZone: 'EST',
         }) as ISODateString,
         activities: [],
@@ -81,22 +61,13 @@ export default function Register<IRegister>() {
         user: IUser
       }>
 
-      const { data } = response
-      setIsLoading(false)
+      const { data: responseData } = response
+      const { message } = responseData
 
-      const { message, details } = data
-
-      setFormData({
-        firstName: '',
-        lastName: '',
-        email: '',
-        password: '',
-        accountType: '',
-      })
+      reset()
       setFormSubmitOutcomeMessage(message)
       router.push('/login')
     } catch (error: any) {
-      setIsLoading(false)
       console.log(error)
 
       if (!error.response) {
@@ -104,14 +75,14 @@ export default function Register<IRegister>() {
         return
       }
 
-      const { status, data } = error.response
+      const { status, data: errorData } = error.response
 
       if (status === 500) {
         setFormSubmitOutcomeMessage(
           'Failed to create user due to an internal error. Please try again later.'
         )
       } else {
-        setFormSubmitOutcomeMessage(data.message)
+        setFormSubmitOutcomeMessage(errorData.message)
       }
     }
   }
@@ -126,7 +97,13 @@ export default function Register<IRegister>() {
         </div>
 
         <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
-          <RegisterForm {...{ handleInput, formData, isLoading, submitForm }} />
+          <RegisterForm
+            register={register}
+            errors={errors}
+            isSubmitting={isSubmitting}
+            onSubmit={handleSubmit(submitForm)}
+            onFieldChange={clearMessage}
+          />
           <div className="submit-form-outcome-message">{formSubmitOutcomeMessage}</div>
         </div>
       </div>

--- a/src/components/activities/add-activity.tsx
+++ b/src/components/activities/add-activity.tsx
@@ -1,91 +1,62 @@
 'use client'
 
-import { useState, FormEvent } from 'react'
+import { useState } from 'react'
 import AddActivityForm from '../forms/add-activity-form'
 import { useCreateActivity } from '@/hooks/use-activity-mutations'
-import { IActivity, IActivityFormData } from '../../types/IActivity'
+import { IActivity } from '../../types/IActivity'
 import { CompletionStatus } from '@/types/CompletionStatusEnum'
 import { ISODateString } from '@/types/isoDateType'
 import { IUser } from '@/types/IUser'
 import { toDbFormat } from '@/lib/helpers/formatActivityName'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { activitySchema, ActivityFormData } from '@/lib/schemas/activity.schemas'
 
-interface IAddActivity {
-  handleInput: (e: React.FormEvent<HTMLInputElement>) => void
-  submitForm: (e: FormEvent<HTMLFormElement>) => Promise<void>
-}
-
-export default function AddActivity<IAddActivity>({ userDetails }: { userDetails: IUser }) {
+export default function AddActivity({ userDetails }: { userDetails: IUser }) {
   const createActivityMutation = useCreateActivity(userDetails.userId)
 
-  const [formData, setFormData] = useState<IActivityFormData>({
-    name: '',
-    description: '',
-    points: 0,
-    hasCards: '',
-  })
-
-  const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [formSubmitOutcomeMessage, setFormSubmitOutcomeMessage] = useState('')
-
-  function handleInput(e: React.FormEvent<HTMLInputElement>) {
-    if (formSubmitOutcomeMessage.length) {
-      setFormSubmitOutcomeMessage('')
-    }
-
-    const target = e.target as HTMLInputElement
-    const fieldName: string = target.name
-    const fieldValue: any = target.value
-
-    setFormData((prevState) => ({
-      ...prevState,
-      [fieldName]: fieldValue,
-    }))
-  }
-
-  function _resetForm() {
-    setFormData({
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ActivityFormData>({
+    resolver: zodResolver(activitySchema),
+    defaultValues: {
       name: '',
       description: '',
       points: 0,
-      hasCards: '',
-    })
-    setIsLoading(false)
+      hasCards: 'false',
+    },
+  })
+
+  const [formSubmitOutcomeMessage, setFormSubmitOutcomeMessage] = useState('')
+
+  function clearMessage() {
+    if (formSubmitOutcomeMessage.length) {
+      setFormSubmitOutcomeMessage('')
+    }
   }
 
-  async function submitForm(e: FormEvent<HTMLFormElement>): Promise<void> {
+  async function submitForm(data: ActivityFormData): Promise<void> {
     try {
-      // We don't want the page to refresh
-      e.preventDefault()
-      setIsLoading(true) // Set loading to true when the request starts
-
-      const formData = new FormData(e.currentTarget)
-      const activityFormInfo: IActivityFormData = {
-        name: '',
-        description: '',
-        points: 0,
-        hasCards: '',
-      }
-
-      for (const pair of formData.entries()) {
-        ;(activityFormInfo as Record<string, any>)[pair[0]] = `${pair[1]}`
-      }
-
-      if (userDetails.activities?.find((activity) => activity.name === activityFormInfo.name)) {
+      if (userDetails.activities?.find((activity) => activity.name === data.name)) {
         setFormSubmitOutcomeMessage('This is already one of your activities.')
-        _resetForm()
+        reset()
         return
       }
 
-      const dbActivityName = toDbFormat(activityFormInfo.name)
+      const dbActivityName = toDbFormat(data.name)
+      const now = new Date()
 
       const userActivity: IActivity = {
-        ...activityFormInfo,
+        ...data,
         activityId: btoa(`${userDetails.email}-${dbActivityName}`),
         name: dbActivityName!,
-        points: Number(activityFormInfo.points),
+        points: Number(data.points),
         completionStatus: CompletionStatus.PENDING,
-        hasCards: activityFormInfo.hasCards === 'true' ? true : false,
-        createdOn: new Date(Date.now()).toLocaleDateString('en-US', {
+        hasCards: data.hasCards === 'true' ? true : false,
+        createdOn: now.toLocaleDateString('en-US', {
           timeZone: 'EST',
         }) as ISODateString,
         lastUpdatedOn: null,
@@ -93,9 +64,8 @@ export default function AddActivity<IAddActivity>({ userDetails }: { userDetails
 
       const response = await createActivityMutation.mutateAsync(userActivity)
       setFormSubmitOutcomeMessage(response.data.message)
-      _resetForm()
+      reset()
     } catch (error: any) {
-      setIsLoading(false)
       console.log(error)
 
       if (!error.response) {
@@ -103,14 +73,14 @@ export default function AddActivity<IAddActivity>({ userDetails }: { userDetails
         return
       }
 
-      const { status, data } = error.response
+      const { status, data: errorData } = error.response
 
       if (status === 500) {
         setFormSubmitOutcomeMessage(
           'Failed to create activity due to an internal error. Please try again later.'
         )
       } else {
-        setFormSubmitOutcomeMessage(data.message)
+        setFormSubmitOutcomeMessage(errorData.message)
       }
     }
   }
@@ -132,7 +102,13 @@ export default function AddActivity<IAddActivity>({ userDetails }: { userDetails
           &#39;Quran&#39; and doesn&#39;t contain &#39;Language&#39;
         </p>
       </div>
-      <AddActivityForm {...{ handleInput, formData, isLoading, submitForm }} />
+      <AddActivityForm
+        register={register}
+        errors={errors}
+        isSubmitting={isSubmitting}
+        onSubmit={handleSubmit(submitForm)}
+        onFieldChange={clearMessage}
+      />
       <div data-testid="add-activity-submit-message">{formSubmitOutcomeMessage}</div>
       <hr className="my-5" />
     </div>

--- a/src/components/forms/add-activity-form.tsx
+++ b/src/components/forms/add-activity-form.tsx
@@ -1,34 +1,34 @@
-import { FormEvent } from 'react'
-import { IActivityFormData } from '../../types/IActivity'
+import { UseFormRegister, FieldErrors } from 'react-hook-form'
+import { ActivityFormData } from '@/lib/schemas/activity.schemas'
 
 export default function AddActivityForm({
-  handleInput,
-  formData,
-  isLoading,
-  submitForm,
+  register,
+  errors,
+  isSubmitting,
+  onSubmit,
+  onFieldChange,
 }: {
-  handleInput: (e: React.FormEvent<HTMLInputElement>) => void
-  formData: IActivityFormData
-  isLoading: boolean
-  submitForm: (e: FormEvent<HTMLFormElement>) => Promise<void>
+  register: UseFormRegister<ActivityFormData>
+  errors: FieldErrors<ActivityFormData>
+  isSubmitting: boolean
+  onSubmit: () => void
+  onFieldChange: () => void
 }) {
   return (
     <>
-      <form data-testid="add-activity-form" className="space-y-6" onSubmit={submitForm}>
+      <form data-testid="add-activity-form" className="space-y-6" onSubmit={onSubmit}>
         <span className="inline-block w-auto mr-2">
           <label htmlFor="name" className="block text-sm font-medium leading-6 text-gray-900">
             Name:
           </label>
           <input
-            onChange={handleInput}
-            value={formData.name}
+            {...register('name', { onChange: onFieldChange })}
             id="name"
-            name="name"
             type="text"
             autoComplete="name"
-            required
             className="inline-block  rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
           />
+          {errors.name && <p className="text-red-500 text-sm">{errors.name.message}</p>}
         </span>
 
         <span className="inline-block w-auto mr-2">
@@ -39,10 +39,8 @@ export default function AddActivityForm({
             Description (optional):
           </label>
           <input
-            onChange={handleInput}
-            value={formData.description}
+            {...register('description', { onChange: onFieldChange })}
             id="description"
-            name="description"
             type="text"
             autoComplete="description"
             className="inline-block  rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
@@ -54,10 +52,8 @@ export default function AddActivityForm({
             Points (optional):
           </label>
           <input
-            onChange={handleInput}
-            value={formData.points}
+            {...register('points', { onChange: onFieldChange, valueAsNumber: true })}
             id="points"
-            name="points"
             type="number"
             className="inline-block rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
           />
@@ -66,12 +62,18 @@ export default function AddActivityForm({
         <fieldset>
           <legend>Has cards?:</legend>
           <div>
-            <input type="radio" id="yesDecks" name="hasCards" value="true" />
+            <input {...register('hasCards')} type="radio" id="yesDecks" value="true" />
             <label htmlFor="yesDecks">Yes</label>
           </div>
 
           <div>
-            <input type="radio" id="noDecks" name="hasCards" value="false" defaultChecked />
+            <input
+              {...register('hasCards')}
+              type="radio"
+              id="noDecks"
+              value="false"
+              defaultChecked
+            />
             <label htmlFor="noDecks">No</label>
           </div>
         </fieldset>
@@ -80,7 +82,7 @@ export default function AddActivityForm({
           <button
             data-testid="add-activity-btn"
             type="submit"
-            disabled={isLoading}
+            disabled={isSubmitting}
             className="default-btn"
           >
             Add activity

--- a/src/components/forms/add-language-card-form.tsx
+++ b/src/components/forms/add-language-card-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FormEvent, useEffect, useState } from 'react'
+import { FormEvent, useState } from 'react'
 import React from 'react'
 import { IActivity } from '@/types/IActivity'
 import { IUser } from '@/types/IUser'
@@ -10,13 +10,11 @@ import { useCreateCards } from '@/hooks/use-card-mutations'
 import { CARD_ACTIVITY_TYPES } from '@/lib/constants/cardTypes'
 import { CompletionStatus } from '@/types/CompletionStatusEnum'
 import { DocumentMinusIcon } from '@heroicons/react/24/solid'
+import { useForm } from 'react-hook-form'
+import { languageCardSchema, LanguageCardFormData } from '@/lib/schemas/card.schemas'
+import { zodResolver } from '@hookform/resolvers/zod'
 
-interface IAddLanguageCardForm {
-  handleInput: (e: React.FormEvent<HTMLInputElement>) => void
-  submitList: (list: string) => Promise<void>
-}
-
-export default function AddLanguageCardForm<IAddLanguageCardForm>({
+export default function AddLanguageCardForm({
   isMain,
   user,
   activity,
@@ -27,12 +25,13 @@ export default function AddLanguageCardForm<IAddLanguageCardForm>({
 }) {
   const createCardsMutation = useCreateCards(user.userId)
 
-  const [file, uploadFile] = useState({
-    content: '',
+  const { register, getValues, setValue } = useForm<LanguageCardFormData>({
+    resolver: zodResolver(languageCardSchema),
+    defaultValues: { words: '' },
   })
 
-  const [typedList, getTypedList] = useState({
-    words: '',
+  const [file, uploadFile] = useState({
+    content: '',
   })
 
   const [shouldUpload, getuploadForm] = useState(false)
@@ -44,8 +43,6 @@ export default function AddLanguageCardForm<IAddLanguageCardForm>({
   const [showModal, setShowModal] = useState(false)
   const [modalType, setModalType] = useState('')
   const [popupItem, getPopupItem] = useState<{ list: string }>({ list: '' })
-
-  useEffect(() => {}, [user, activity, file])
 
   async function onFileInput(e: React.FormEvent<HTMLInputElement>) {
     const files = (e.target as HTMLInputElement).files
@@ -66,14 +63,6 @@ export default function AddLanguageCardForm<IAddLanguageCardForm>({
     const uploadInput = document.querySelector('#upload') as HTMLInputElement
     uploadFile({ content: '' })
     uploadInput.value = ''
-  }
-
-  function onTextareaChange(e: React.FormEvent<HTMLTextAreaElement>) {
-    const target = e.target as HTMLTextAreaElement
-    setFormSubmitOutcomeMessage('')
-    getTypedList({
-      words: target.value,
-    })
   }
 
   function cleanUpList(list: string) {
@@ -111,7 +100,7 @@ export default function AddLanguageCardForm<IAddLanguageCardForm>({
     setFormSubmitOutcomeMessage('')
     const languageCardType = (e.target as HTMLSelectElement).value
 
-    ;(document.querySelector('#typed') as HTMLTextAreaElement).value = ''
+    setValue('words', '')
     if (languageCardType === 'Vocab card') {
       createVocabCard(true)
       createGrammarCard(false)
@@ -135,18 +124,17 @@ export default function AddLanguageCardForm<IAddLanguageCardForm>({
     e.preventDefault()
     setFormSubmitOutcomeMessage('')
 
-    if (
-      ((shouldType || grammarCard) && typedList.words === '') ||
-      (shouldUpload && file.content === '')
-    ) {
+    const words = getValues('words')
+
+    if (((shouldType || grammarCard) && words === '') || (shouldUpload && file.content === '')) {
       setFormSubmitOutcomeMessage('Oops, you are trying to validate an empty list')
       return
     }
 
     let listOfItemsToValidate = ''
     if (shouldType || grammarCard) {
-      listOfItemsToValidate = cleanUpList(typedList.words)
-      ;(document.querySelector('#typed') as HTMLTextAreaElement).value = listOfItemsToValidate
+      listOfItemsToValidate = cleanUpList(words)
+      setValue('words', listOfItemsToValidate)
     } else if (shouldUpload) {
       listOfItemsToValidate = file.content
     }
@@ -355,9 +343,8 @@ export default function AddLanguageCardForm<IAddLanguageCardForm>({
           <textarea
             data-testid="textarea-for-typed-list"
             className="border border-gray-500 p-3"
-            onChange={onTextareaChange}
+            {...register('words')}
             id="typed"
-            name="typed"
             rows={4}
             cols={50}
           ></textarea>

--- a/src/components/forms/add-misc-card-form.tsx
+++ b/src/components/forms/add-misc-card-form.tsx
@@ -9,6 +9,9 @@ import Popup from '../popups/popup'
 import { useCreateCards } from '@/hooks/use-card-mutations'
 import { CompletionStatus } from '@/types/CompletionStatusEnum'
 import { CARD_ACTIVITY_TYPES } from '@/lib/constants/cardTypes'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { miscCardSchema, MiscCardFormData } from '@/lib/schemas/card.schemas'
 
 export default function AddMiscCardForm({
   isMain,
@@ -21,8 +24,9 @@ export default function AddMiscCardForm({
 }) {
   const createCardsMutation = useCreateCards(user.userId)
 
-  const [typedList, getTypedList] = useState({
-    words: '',
+  const { register, getValues, setValue, formState } = useForm<MiscCardFormData>({
+    resolver: zodResolver(miscCardSchema),
+    defaultValues: { words: '' },
   })
 
   const [formSubmitOutcomeMessage, setFormSubmitOutcomeMessage] = useState('')
@@ -30,15 +34,6 @@ export default function AddMiscCardForm({
   const [popupItem, getPopupItem] = useState<{ list: string }>({ list: '' })
   const [showModal, setShowModal] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-
-  function onTextareaChange(e: React.FormEvent<HTMLTextAreaElement>) {
-    const target = e.target as HTMLTextAreaElement
-
-    setFormSubmitOutcomeMessage('')
-    getTypedList({
-      words: target.value,
-    })
-  }
 
   async function submitList(finalCardList: string) {
     setFormSubmitOutcomeMessage('')
@@ -94,13 +89,14 @@ export default function AddMiscCardForm({
     e.preventDefault()
     setFormSubmitOutcomeMessage('')
 
-    if (typedList.words === '') {
+    const words = getValues('words')
+    if (words === '') {
       setFormSubmitOutcomeMessage('Oops, you are trying to validate an empty list')
       return
     }
 
-    const listOfItemsToValidate = cleanUpList(typedList.words)
-    ;(document.querySelector('#typed') as HTMLTextAreaElement).value = listOfItemsToValidate
+    const listOfItemsToValidate = cleanUpList(words)
+    setValue('words', listOfItemsToValidate)
 
     getPopupItem({ list: listOfItemsToValidate })
     setModalType('validate')
@@ -144,9 +140,8 @@ export default function AddMiscCardForm({
           <textarea
             data-testid="textarea-for-typed-list"
             className="border border-gray-500 p-3"
-            onChange={onTextareaChange}
+            {...register('words')}
             id="typed"
-            name="typed"
             rows={4}
             cols={50}
           ></textarea>

--- a/src/components/forms/add-quran-card-form.tsx
+++ b/src/components/forms/add-quran-card-form.tsx
@@ -9,14 +9,11 @@ import { IUser } from '@/types/IUser'
 import { useCreateCards, useDeleteCard } from '@/hooks/use-card-mutations'
 import { quranCards } from '@/lib/constants/quran-bank'
 import { CompletionStatus } from '@/types/CompletionStatusEnum'
-import { ISODateString } from '@/types/isoDateType'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { quranCustomSchema, QuranCustomFormData } from '@/lib/schemas/card.schemas'
 
-interface IAddQuranCardForm {
-  handleInput: (e: React.FormEvent<HTMLInputElement>) => void
-  submitForm: (e: FormEvent<HTMLFormElement>) => Promise<void>
-}
-
-export default function AddQuranCardForm<IAddQuranCardForm>({
+export default function AddQuranCardForm({
   isMain,
   user,
   activity,
@@ -28,10 +25,16 @@ export default function AddQuranCardForm<IAddQuranCardForm>({
   const createCardsMutation = useCreateCards(user.userId)
   const deleteCardMutation = useDeleteCard(user.userId)
 
-  const [formData, setFormData] = useState<IQuranCards[]>([])
-  const [custom, setCustom] = useState({
-    content: '',
+  const {
+    register,
+    getValues,
+    reset: resetForm,
+  } = useForm<QuranCustomFormData>({
+    resolver: zodResolver(quranCustomSchema),
+    defaultValues: { content: '' },
   })
+
+  const [formData, setFormData] = useState<IQuranCards[]>([])
   const [selectedCards, setSelectedCards] = useState<string[]>([])
   const [selectedJuz, setSelectedJuz] = useState<number[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(false)
@@ -59,9 +62,8 @@ export default function AddQuranCardForm<IAddQuranCardForm>({
       return card
     })
 
-    setCustom(custom)
     setFormData([...cardsToDisplay])
-  }, [user, activity, custom])
+  }, [user, activity])
 
   function Checkboxes({ quranCard, handleInput }: { quranCard: any; handleInput: any }) {
     if (quranCard.level === 'Juz') {
@@ -155,29 +157,12 @@ export default function AddQuranCardForm<IAddQuranCardForm>({
     setSelectedCards([...alreadySelected])
   }
 
-  function handleCustomInput(e: React.FormEvent<HTMLInputElement>) {
-    const target = e.target as HTMLInputElement
-    const fieldName: string = target.name
-    const fieldValue: any = target.value
-
-    setCustom((prevState) => ({
-      ...prevState,
-      [fieldName]: fieldValue,
-    }))
-  }
-
   async function submitForm(e: FormEvent<HTMLFormElement>): Promise<any> {
     e.preventDefault()
     try {
-      const rawFormData = new FormData(e.currentTarget)
-      const jsonData: Record<string, string> = {
-        content: '',
-      }
-      for (const pair of rawFormData.entries()) {
-        jsonData[pair[0].trim()] = `${(pair[1] as string).trim()}`
-      }
+      const customContent = getValues('content').trim()
 
-      if (!selectedCards.length && jsonData.content === '') {
+      if (!selectedCards.length && customContent === '') {
         setFormSubmitOutcomeMessage('Please select the cards you want to add.')
         return
       }
@@ -212,9 +197,9 @@ export default function AddQuranCardForm<IAddQuranCardForm>({
         }
       })
 
-      if (jsonData.content !== '') {
+      if (customContent !== '') {
         cards.push({
-          cardId: `${btoa(`custom-${jsonData.content}`)}`,
+          cardId: `${btoa(`custom-${customContent}`)}`,
           activity: activity.name,
           activityType: CARD_ACTIVITY_TYPES.QURAN,
           addedOn: null,
@@ -284,11 +269,9 @@ export default function AddQuranCardForm<IAddQuranCardForm>({
               Custom (Surah name range start to range end):
             </label>
             <input
-              onChange={handleCustomInput}
-              value={custom.content}
+              {...register('content')}
               data-testid="custom-quran"
               id="content"
-              name="content"
               type="text"
               className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
               placeholder="Naas 1 to 2"

--- a/src/components/forms/search-user-form.tsx
+++ b/src/components/forms/search-user-form.tsx
@@ -1,40 +1,36 @@
-import { FormEvent } from 'react'
+import { UseFormRegister, FieldErrors } from 'react-hook-form'
+import { SearchStudentFormData } from '@/lib/schemas/student.schemas'
 
 export default function SearchUserForm({
-  handleInput,
-  formData,
-  isLoading,
-  submitForm,
+  register,
+  errors,
+  isSubmitting,
+  onSubmit,
+  onFieldChange,
 }: {
-  handleInput: (e: React.FormEvent<HTMLInputElement>) => void
-  formData: { email: string }
-  isLoading: boolean
-  submitForm: (e: FormEvent<HTMLFormElement>) => Promise<void>
+  register: UseFormRegister<SearchStudentFormData>
+  errors: FieldErrors<SearchStudentFormData>
+  isSubmitting: boolean
+  onSubmit: () => void
+  onFieldChange: () => void
 }) {
   return (
     <>
-      <form
-        data-testid="find-student-form"
-        className="space-y-6"
-        onSubmit={submitForm}
-        method="POST"
-      >
+      <form data-testid="find-student-form" className="space-y-6" onSubmit={onSubmit} method="POST">
         <input
           data-testid="student-email"
-          onChange={handleInput}
-          value={formData.email}
+          {...register('email', { onChange: onFieldChange })}
           id="email"
-          name="email"
           type="text"
           autoComplete="email"
-          required
           className="inline-block  rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
         />
+        {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
         <span>
           <button
             data-testid="find-student-btn"
             type="submit"
-            disabled={isLoading}
+            disabled={isSubmitting}
             className="ml-2 default-btn"
           >
             Find Student

--- a/src/components/popups/deleteActivityPopup.tsx
+++ b/src/components/popups/deleteActivityPopup.tsx
@@ -22,7 +22,6 @@ export default function DeleteActivityPopup({
   const [outcomeMessage, setOutcomeMessage] = useState('')
 
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     getActivityName(item!.activityName)
     getUserInfo({ ...user })
   }, [showModal, user, item])

--- a/src/components/popups/manageCardPopup.tsx
+++ b/src/components/popups/manageCardPopup.tsx
@@ -40,7 +40,7 @@ export default function ManageCardPopup({
   const requestReviewMutation = useRequestCardReview()
 
   const [userInfo, getUserInfo] = useState<IUser | Partial<IUser>>({ ...user })
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
   const [card, getCardDetails] = useState<ICard>({ ...item!.card })
   const [activity, getActivityDetails] = useState<IActivity>({ ...activityProp } as IActivity)
   const [statusMessage, setStatusMessage] = useState('')
@@ -48,10 +48,9 @@ export default function ManageCardPopup({
   const [newStage, setNewStage] = useState('')
 
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     getCardDetails(item!.card)
     getUserInfo({ ...user })
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
     getActivityDetails(activityProp!)
     setStatusMessage('')
   }, [showModal, user, item, activityProp, newStage])

--- a/src/components/popups/validatePopup.tsx
+++ b/src/components/popups/validatePopup.tsx
@@ -17,7 +17,6 @@ export default function ValidatePopup({
   const [itemsToValidate, getItemsToValidate] = useState('')
 
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     getItemsToValidate(item!.list)
   }, [showModal, item])
 

--- a/src/components/students/add-student.tsx
+++ b/src/components/students/add-student.tsx
@@ -1,86 +1,60 @@
 'use client'
 
-import { useState, FormEvent } from 'react'
+import { useState } from 'react'
 import { findUser } from '../../api/controller'
 import SearchUserForm from '../forms/search-user-form'
 import Popup from '../popups/popup'
 import { IUser } from '@/types/IUser'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { searchStudentSchema, SearchStudentFormData } from '@/lib/schemas/student.schemas'
 
-interface IAddStudent {
-  handleInput: (e: React.FormEvent<HTMLInputElement>) => void
-  submitForm: (e: FormEvent<HTMLFormElement>) => Promise<void>
-}
-
-export default function AddStudent<IAddStudent>({ user }: { user: IUser }) {
-  const [formData, setFormData] = useState({
-    email: '',
+export default function AddStudent({ user }: { user: IUser }) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<SearchStudentFormData>({
+    resolver: zodResolver(searchStudentSchema),
+    defaultValues: { email: '' },
   })
 
-  const [isLoading, setIsLoading] = useState<boolean>(false)
   const [formSubmitOutcomeMessage, setFormSubmitOutcomeMessage] = useState('')
   const [newStudent, getStudentInfo] = useState<IUser>({} as IUser)
   const [showModal, setShowModal] = useState(false)
 
   const modalType = 'addStudent'
 
-  function handleInput(e: React.FormEvent<HTMLInputElement>) {
+  function clearMessage() {
     if (formSubmitOutcomeMessage.length) {
       setFormSubmitOutcomeMessage('')
     }
-
-    const target = e.target as HTMLInputElement
-    const fieldName: string = target.name
-    const fieldValue: any = target.value
-
-    setFormData((prevState) => ({
-      ...prevState,
-      [fieldName]: fieldValue,
-    }))
   }
 
-  function _resetForm() {
-    setFormData({
-      email: '',
-    })
-    setIsLoading(false)
-  }
-
-  async function submitForm(e: FormEvent<HTMLFormElement>): Promise<void> {
+  async function submitForm(data: SearchStudentFormData): Promise<void> {
     try {
-      // We don't want the page to refresh
-      e.preventDefault()
-      setIsLoading(true) // Set loading to true when the request starts
-
-      const formData = new FormData(e.currentTarget)
-      const newStudent = { email: '' }
-
-      for (const pair of formData.entries()) {
-        ;(newStudent as Record<string, string>)[pair[0]] = `${pair[1]}`
-      }
-
-      if (newStudent.email === user.email) {
+      if (data.email === user.email) {
         setFormSubmitOutcomeMessage("You can't add yourself as a student.")
-        _resetForm()
+        reset()
         return
       }
 
       const currentStudents = user?.linkedAccountsData?.students
-      if (currentStudents?.some((tuple) => tuple[0] === btoa(newStudent.email))) {
+      if (currentStudents?.some((tuple) => tuple[0] === btoa(data.email))) {
         setFormSubmitOutcomeMessage('This is already one of your students.')
-        _resetForm()
+        reset()
         return
       }
 
-      const newStudentUserId = { userId: btoa(newStudent.email) }
+      const newStudentUserId = { userId: btoa(data.email) }
 
       const response = await findUser(newStudentUserId)
-      const { data } = response
-      const { details }: { message: string; details: { student: IUser } } = data
-      setIsLoading(false)
+      const { data: responseData } = response
+      const { details }: { message: string; details: { student: IUser } } = responseData
       getStudentInfo(details.student)
       setShowModal(true)
     } catch (error: any) {
-      setIsLoading(false)
       console.log(error)
 
       if (!error.response) {
@@ -88,14 +62,14 @@ export default function AddStudent<IAddStudent>({ user }: { user: IUser }) {
         return
       }
 
-      const { status, data } = error.response
+      const { status, data: errorData } = error.response
 
       if (status === 500) {
         setFormSubmitOutcomeMessage(
           'Failed to add new student due to an internal error. Please try again later.'
         )
       } else {
-        setFormSubmitOutcomeMessage(data.message)
+        setFormSubmitOutcomeMessage(errorData.message)
       }
     }
   }
@@ -104,7 +78,13 @@ export default function AddStudent<IAddStudent>({ user }: { user: IUser }) {
     <div className="justify-items-start">
       <h3 className="component-sub-title">Add a new student:</h3>
       <p>Enter your student&#39;s email:</p>
-      <SearchUserForm {...{ handleInput, formData, isLoading, submitForm }} />
+      <SearchUserForm
+        register={register}
+        errors={errors}
+        isSubmitting={isSubmitting}
+        onSubmit={handleSubmit(submitForm)}
+        onFieldChange={clearMessage}
+      />
       <Popup {...{ showModal, modalType, user, newStudent }} onClose={() => setShowModal(false)} />
       <div data-testid="find-student-submit-message">{formSubmitOutcomeMessage}</div>
     </div>

--- a/src/lib/schemas/activity.schemas.ts
+++ b/src/lib/schemas/activity.schemas.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const activitySchema = z.object({
+  name: z.string().min(1, 'Activity name is required'),
+  description: z.string(),
+  points: z.number(),
+  hasCards: z.enum(['true', 'false']),
+})
+
+export type ActivityFormData = z.infer<typeof activitySchema>

--- a/src/lib/schemas/auth.schemas.ts
+++ b/src/lib/schemas/auth.schemas.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+export const loginSchema = z.object({
+  email: z.string().min(1, 'Email is required'),
+  password: z.string().min(1, 'Password is required'),
+})
+
+export type LoginFormData = z.infer<typeof loginSchema>
+
+export const registerSchema = z.object({
+  firstName: z.string().min(1, 'First name is required'),
+  lastName: z.string().min(1, 'Last name is required'),
+  email: z.string().min(1, 'Email is required').email('Please enter a valid email'),
+  password: z.string().min(1, 'Password is required'),
+  accountType: z.enum(['student', 'teacher'], { message: 'Account type is required' }),
+})
+
+export type RegisterFormData = z.infer<typeof registerSchema>

--- a/src/lib/schemas/card.schemas.ts
+++ b/src/lib/schemas/card.schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+export const miscCardSchema = z.object({
+  words: z.string().min(1, 'Please enter at least one card'),
+})
+
+export type MiscCardFormData = z.infer<typeof miscCardSchema>
+
+export const languageCardSchema = z.object({
+  words: z.string().min(1, 'Please enter at least one item'),
+})
+
+export type LanguageCardFormData = z.infer<typeof languageCardSchema>
+
+export const quranCustomSchema = z.object({
+  content: z.string(),
+})
+
+export type QuranCustomFormData = z.infer<typeof quranCustomSchema>

--- a/src/lib/schemas/student.schemas.ts
+++ b/src/lib/schemas/student.schemas.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const searchStudentSchema = z.object({
+  email: z.string().min(1, 'Email is required'),
+})
+
+export type SearchStudentFormData = z.infer<typeof searchStudentSchema>

--- a/src/specs/app/register/register.test.tsx
+++ b/src/specs/app/register/register.test.tsx
@@ -48,7 +48,7 @@ async function fillTeacherRegisterForm() {
   const lastName = screen.getByLabelText(/Last Name:/i)
   const password = screen.getByLabelText(/Password:/i)
   const email = screen.getByLabelText(/Email:/i)
-  const teacherRadio = screen.getByDisplayValue(/Student/i)
+  const teacherRadio = screen.getByLabelText(/Teacher/i)
 
   await act(() => {
     // fill out the form
@@ -64,9 +64,7 @@ async function fillTeacherRegisterForm() {
     fireEvent.change(email, {
       target: { value: 'mock.user@email.com' },
     })
-    fireEvent.change(teacherRadio, {
-      target: { value: 'teacher' },
-    })
+    fireEvent.click(teacherRadio)
   })
 }
 

--- a/src/types/IActivity.ts
+++ b/src/types/IActivity.ts
@@ -13,8 +13,3 @@ export interface IActivity {
   lastUpdatedOn: ISODateString | null
   cards?: ICard[] | []
 }
-
-export type IActivityFormData = Omit<
-  IActivity,
-  'activityId' | 'completionStatus' | 'createdOn' | 'lastUpdatedOn' | 'cards'
->

--- a/src/types/IUser.ts
+++ b/src/types/IUser.ts
@@ -16,11 +16,4 @@ export interface IUser {
   students?: Record<string, IUser>
 }
 
-export type IUserFormData = Required<
-  Omit<
-    IUser,
-    'userId' | 'username' | 'lastLogin' | 'activities' | 'linkedAccountsData' | 'students'
-  >
->
-
 export type IUserLogin = Pick<IUser, 'userId' | 'password'> & Partial<Pick<IUser, 'userId'>>


### PR DESCRIPTION
## Summary by Sourcery

Migrate authentication and data flow from Redux/sessionStorage to next-auth with React Query, updating components, hooks, tests, and Cypress journeys to use server-backed user/session data and query-based mutations instead of direct store updates and page reloads.

New Features:
- Introduce next-auth credential-based authentication with custom auth handlers, middleware, and providers, including session-based navigation guards.
- Add React Query hooks and query keys for fetching and mutating users, students, activities, and cards, plus shared AppProviders for query/session context.
- Add Cypress helpers and tasks for logging in via next-auth sessions and new end-to-end journeys covering teacher management of student cards.

Bug Fixes:
- Ensure student card mutations invalidate both teacher and student views by correctly targeting React Query cache keys.
- Prevent UI crashes or stale state when required user or student IDs are missing by adding explicit guards and error messaging in popups and layouts.
- Stabilize activity creation and student flows in Cypress tests by waiting on data loading hooks instead of relying on sessionStorage timing.

Enhancements:
- Refactor card, activity, student, and account management flows to use mutation hooks and close popups or update status messages instead of forcing full page reloads.
- Simplify layout and page components to derive user and student data from next-auth sessions and React Query rather than Redux store access.
- Improve API controller typings and axios service configuration, including a shared instance with optional bearer token injection from the current session.
- Streamline Navbar, forms, and lists to work directly with hook-derived user IDs and props, and adjust tests to the new data access patterns.
- Refine Jest configuration and test utilities to better support React Query, next-auth, and ESM dependencies.

Build:
- Update dependencies to add next-auth and @tanstack/react-query, remove Redux-related packages, and adjust formatting and dev scripts for the new stack.

CI:
- Adjust CircleCI Cypress job to build the Next.js app once and run tests against the production build with nyc coverage.

Documentation:
- Expand Cypress USER_JOURNEYS to cover navigation, error cases, and teacher-managing-student scenarios, marking missing specs for future coverage.

Tests:
- Extensively update Jest tests and Cypress specs to align with next-auth/React Query flows, remove Redux/sessionStorage coupling, and add new unit tests for card mutation hooks and axios service mocking.