### PR TITLE
refactor(6.4): extract hooks and remove props-to-state antipattern

### DIFF
--- a/src/components/lists/cards-list.tsx
+++ b/src/components/lists/cards-list.tsx
@@ -1,15 +1,15 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import Popup, { CardAction } from '../popups/popup'
 import { ICard } from '@/types/ICard'
 import { IUser } from '@/types/IUser'
-import { CompletionStatus } from '@/types/CompletionStatusEnum'
 import AddCard from '../cards/add-card'
 import { IActivity } from '@/types/IActivity'
 import { useMounted } from '@/lib/helpers/useMounted'
 import { getBorderColor } from '@/lib/helpers/getBorderColor'
 import formatCardName from '@/lib/helpers/formatCardName'
+import { useCardFiltering } from '@/hooks/use-card-filtering'
 import {
   DocumentMinusIcon,
   DocumentPlusIcon,
@@ -28,63 +28,19 @@ export default function CardsList({
   activity?: IActivity
 }) {
   const mounted = useMounted()
+  const { cardsOfTheDay, allActiveCards, allInactiveCards, hash } = useCardFiltering(
+    activity,
+    userDetails,
+    mounted
+  )
 
   const [showModal, setShowModal] = useState(false)
   const [popupItem, setPopupItem] = useState<{ card: ICard; action: CardAction }>(
     {} as { card: ICard; action: CardAction }
   )
-  const [popupUserDetails, setPopupUserDetails] = useState<IUser>({} as IUser)
-  const [cardsOfTheDay, setCardsOfTheDay] = useState<ICard[]>([])
-  const [allActiveCards, setAllActiveCards] = useState<ICard[]>([])
-  const [allInactiveCards, setAllInactiveCards] = useState<ICard[]>([])
-  const [hash, setHash] = useState('')
-
-  useEffect(() => {
-    const cards: any[] | ICard = activity?.cards || []
-
-    if (cards.length) {
-      cards.map((card) => {
-        let num = `${atob(card.cardId).split('-')[1]}`
-        if (num.length === 1) {
-          card.number = `00${num}`
-        } else if (num.length === 2) {
-          card.number = `0${num}`
-        } else {
-          card.number = `${num}`
-        }
-      })
-      cards.sort((a, b) => a.number - b.number)
-      cards.map((card) => delete card.number)
-    }
-
-    const todayCards = cards?.filter((card) => {
-      return (
-        card.completionStatus === CompletionStatus.REVIEW ||
-        (card.completionStatus !== CompletionStatus.INACTIVE &&
-          card.completionStatus !== CompletionStatus.COMPLETED &&
-          (new Date().toLocaleDateString('en-US', { timeZone: 'EST' }) === card.nextShowDate ||
-            new Date().toLocaleDateString('en-US', { timeZone: 'EST' }) === card.addedOn))
-      )
-    })
-    setCardsOfTheDay(todayCards)
-
-    const activeCards = cards?.filter((card) => card.completionStatus !== CompletionStatus.INACTIVE)
-    setAllActiveCards(activeCards)
-
-    const inactiveCards = cards?.filter(
-      (card) => card.completionStatus === CompletionStatus.INACTIVE
-    )
-    setAllInactiveCards(inactiveCards)
-
-    if (mounted) {
-      const hashReducer = window.location.hash
-      setHash(hashReducer)
-    }
-  }, [userDetails, activity, mounted])
 
   function openCardPopup(card: ICard, action: CardAction) {
     setPopupItem({ card, action })
-    setPopupUserDetails(userDetails)
     setShowModal(true)
   }
 
@@ -333,7 +289,7 @@ export default function CardsList({
           config={{
             type: 'manageCard',
             isMain,
-            user: popupUserDetails,
+            user: userDetails,
             activity: activity!,
             item: popupItem,
           }}

--- a/src/components/lists/cards-list.tsx
+++ b/src/components/lists/cards-list.tsx
@@ -30,7 +30,6 @@ export default function CardsList({
   const mounted = useMounted()
   const { cardsOfTheDay, allActiveCards, allInactiveCards, hash } = useCardFiltering(
     activity,
-    userDetails,
     mounted
   )
 

--- a/src/components/popups/deleteAccountPopup.tsx
+++ b/src/components/popups/deleteAccountPopup.tsx
@@ -1,5 +1,4 @@
 import { deleteUser } from '../../api/controller'
-import { useEffect, useState } from 'react'
 import { signOut } from 'next-auth/react'
 import { IUser } from '@/types/IUser'
 import { IResponse } from '@/types/IApiResponse'
@@ -16,15 +15,9 @@ export default function DeleteAccountPopup({
   showModal: boolean
   user?: IUser | Partial<IUser>
 }) {
-  const [userInfo, getUserInfo] = useState<IUser | Partial<IUser>>({ ...user })
-
-  useEffect(() => {
-    getUserInfo({ ...user })
-  }, [showModal, user])
-
   async function deleteAccount() {
     try {
-      ;(await deleteUser(userInfo.userId!)) as unknown as IResponse
+      ;(await deleteUser(user!.userId!)) as unknown as IResponse
       await onDeleteAccountSuccess()
     } catch (error: unknown) {
       handleMutationError(error, 'delete account')
@@ -74,9 +67,7 @@ export default function DeleteAccountPopup({
                   Are you sure you want to delete this account forever?
                 </h3>
                 <h5 className="mb-5">
-                  <span>
-                    {`${userInfo?.firstName} ${userInfo?.lastName} - ${userInfo?.email}`}{' '}
-                  </span>
+                  <span>{`${user?.firstName} ${user?.lastName} - ${user?.email}`} </span>
                 </h5>
               </div>
 

--- a/src/components/popups/deleteAccountPopup.tsx
+++ b/src/components/popups/deleteAccountPopup.tsx
@@ -13,11 +13,11 @@ export default function DeleteAccountPopup({
 }: {
   onClose: () => void
   showModal: boolean
-  user?: IUser | Partial<IUser>
+  user: IUser | Partial<IUser>
 }) {
   async function deleteAccount() {
     try {
-      ;(await deleteUser(user!.userId!)) as unknown as IResponse
+      ;(await deleteUser(user.userId!)) as unknown as IResponse
       await onDeleteAccountSuccess()
     } catch (error: unknown) {
       handleMutationError(error, 'delete account')

--- a/src/components/popups/deleteActivityPopup.tsx
+++ b/src/components/popups/deleteActivityPopup.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { useDeleteActivity } from '@/hooks/use-activity-mutations'
 import { IUser } from '@/types/IUser'
 import { BoltSlashIcon, XMarkIcon } from '@heroicons/react/24/solid'
@@ -19,18 +18,10 @@ export default function DeleteActivityPopup({
   const userId = user?.userId ?? ''
   const deleteActivityMutation = useDeleteActivity(userId)
 
-  const [userInfo, getUserInfo] = useState<IUser | Partial<IUser>>({ ...user })
-  const [activityName, getActivityName] = useState('')
-
-  useEffect(() => {
-    getActivityName(item!.activityName)
-    getUserInfo({ ...user })
-  }, [showModal, user, item])
-
   async function deleteUserActivity() {
     try {
       if (!userId) throw new Error('Missing userId for deleteActivity')
-      await deleteActivityMutation.mutateAsync(activityName)
+      await deleteActivityMutation.mutateAsync(item!.activityName)
       toast.success('Successfully deleted activity')
       onClose()
     } catch (error: unknown) {
@@ -81,7 +72,7 @@ export default function DeleteActivityPopup({
                   Are you sure you want to delete this activity?
                 </h3>
                 <h5 className="mb-5">
-                  <span>{activityName}</span>
+                  <span>{item?.activityName}</span>
                 </h5>
               </div>
 

--- a/src/components/popups/deleteActivityPopup.tsx
+++ b/src/components/popups/deleteActivityPopup.tsx
@@ -12,16 +12,16 @@ export default function DeleteActivityPopup({
 }: {
   onClose: () => void
   showModal: boolean
-  user?: IUser | Partial<IUser>
-  item?: { activityName: string }
+  user: IUser | Partial<IUser>
+  item: { activityName: string }
 }) {
-  const userId = user?.userId ?? ''
+  const userId = user.userId ?? ''
   const deleteActivityMutation = useDeleteActivity(userId)
 
   async function deleteUserActivity() {
     try {
       if (!userId) throw new Error('Missing userId for deleteActivity')
-      await deleteActivityMutation.mutateAsync(item!.activityName)
+      await deleteActivityMutation.mutateAsync(item.activityName)
       toast.success('Successfully deleted activity')
       onClose()
     } catch (error: unknown) {
@@ -72,7 +72,7 @@ export default function DeleteActivityPopup({
                   Are you sure you want to delete this activity?
                 </h3>
                 <h5 className="mb-5">
-                  <span>{item?.activityName}</span>
+                  <span>{item.activityName}</span>
                 </h5>
               </div>
 

--- a/src/components/popups/linkAccountPopup.tsx
+++ b/src/components/popups/linkAccountPopup.tsx
@@ -12,16 +12,16 @@ export default function LinkAccountPopup({
 }: {
   onClose: () => void
   showModal: boolean
-  newStudent?: IUser | Partial<IUser>
-  user?: IUser | Partial<IUser>
+  newStudent: IUser | Partial<IUser>
+  user: IUser | Partial<IUser>
 }) {
-  const teacherId = user?.userId ?? ''
+  const teacherId = user.userId ?? ''
   const linkStudentMutation = useLinkStudent(teacherId)
 
   async function addStudent() {
     try {
       if (!teacherId) throw new Error('Missing teacherId for linkStudent')
-      await linkStudentMutation.mutateAsync([newStudent!.userId!, newStudent!.username!])
+      await linkStudentMutation.mutateAsync([newStudent.userId!, newStudent.username!])
       toast.success('Successfully added a new student')
       onClose()
     } catch (error: unknown) {

--- a/src/components/popups/linkAccountPopup.tsx
+++ b/src/components/popups/linkAccountPopup.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { useLinkStudent } from '@/hooks/use-student-mutations'
 import { IUser } from '@/types/IUser'
 import { LinkIcon, XMarkIcon } from '@heroicons/react/24/solid'
@@ -19,18 +18,10 @@ export default function LinkAccountPopup({
   const teacherId = user?.userId ?? ''
   const linkStudentMutation = useLinkStudent(teacherId)
 
-  const [studentInfo, getStudentInfo] = useState<IUser | Partial<IUser>>({ ...newStudent })
-  const [teacher, getTeacherData] = useState<IUser | Partial<IUser>>({ ...user })
-
-  useEffect(() => {
-    getStudentInfo({ ...newStudent })
-    getTeacherData({ ...user })
-  }, [showModal, newStudent, user])
-
   async function addStudent() {
     try {
       if (!teacherId) throw new Error('Missing teacherId for linkStudent')
-      await linkStudentMutation.mutateAsync([studentInfo.userId!, studentInfo.username!])
+      await linkStudentMutation.mutateAsync([newStudent!.userId!, newStudent!.username!])
       toast.success('Successfully added a new student')
       onClose()
     } catch (error: unknown) {
@@ -82,7 +73,7 @@ export default function LinkAccountPopup({
                 </h3>
                 <h5 className="mb-5">
                   <span>
-                    {studentInfo?.firstName} {studentInfo?.lastName} - {studentInfo?.email}{' '}
+                    {newStudent?.firstName} {newStudent?.lastName} - {newStudent?.email}{' '}
                   </span>
                 </h5>
               </div>

--- a/src/components/popups/manageCardPopup.tsx
+++ b/src/components/popups/manageCardPopup.tsx
@@ -1,12 +1,3 @@
-import { useEffect, useState } from 'react'
-import {
-  useEditCard,
-  useEditCardStage,
-  useResetCardStage,
-  useActivateCard,
-  useDeleteCard,
-  useRequestCardReview,
-} from '@/hooks/use-card-mutations'
 import { ICard } from '@/types/ICard'
 import { IUser } from '@/types/IUser'
 import { CompletionStatus } from '@/types/CompletionStatusEnum'
@@ -15,9 +6,8 @@ import { CARD_ACTIVITY_TYPES } from '@/lib/constants/cardTypes'
 import { IActivity } from '@/types/IActivity'
 import formatCardName from '@/lib/helpers/formatCardName'
 import { ClipboardDocumentCheckIcon, XMarkIcon } from '@heroicons/react/24/solid'
-import { toast } from 'sonner'
-import { handleMutationError } from '@/lib/helpers/mutation-error-handler'
 import { CardAction } from './popup'
+import { useCardActions } from '@/hooks/use-card-actions'
 
 export default function ManageCardPopup({
   onClose,
@@ -25,7 +15,7 @@ export default function ManageCardPopup({
   isMain,
   user,
   item,
-  activity: activityProp,
+  activity,
 }: {
   onClose: () => void
   showModal: boolean
@@ -35,140 +25,17 @@ export default function ManageCardPopup({
   item?: { card: ICard; action: CardAction }
 }) {
   const userId = user?.userId ?? ''
-  const editCardMutation = useEditCard(userId)
-  const editCardStageMutation = useEditCardStage(userId)
-  const resetCardStageMutation = useResetCardStage(userId)
-  const activateCardMutation = useActivateCard(userId)
-  const deleteCardMutation = useDeleteCard(userId)
-  const requestReviewMutation = useRequestCardReview()
-
-  const [userInfo, getUserInfo] = useState<IUser | Partial<IUser>>({ ...user })
-
-  const [card, getCardDetails] = useState<ICard>({ ...item!.card })
-  const [activity, getActivityDetails] = useState<IActivity>({ ...activityProp } as IActivity)
-  const [newStage, setNewStage] = useState('')
-
-  useEffect(() => {
-    getCardDetails(item!.card)
-    getUserInfo({ ...user })
-
-    getActivityDetails(activityProp!)
-  }, [showModal, user, item, activityProp, newStage])
-
-  function assertUserId() {
-    if (!userId) throw new Error('Missing userId for card mutation')
-  }
-
-  async function resetStage() {
-    try {
-      assertUserId()
-      await resetCardStageMutation.mutateAsync({
-        activity: activity.name,
-        cardId: card.cardId,
-      })
-      toast.success('Successfully reset card')
-      onClose()
-    } catch (error: unknown) {
-      handleMutationError(error, 'reset card')
-    }
-  }
-
-  async function submitForReview() {
-    try {
-      assertUserId()
-      const requestReview = {
-        id: card.cardId,
-        teacherId: userInfo.linkedAccountsData!.teacher!,
-        student: {
-          id: userInfo.userId!,
-          fullName: `${userInfo.firstName} ${userInfo.lastName}`,
-          email: userInfo.email!,
-        },
-      }
-
-      await requestReviewMutation.mutateAsync(requestReview)
-
-      await editCardStageMutation.mutateAsync({
-        activity: activity.name,
-        cardId: card.cardId,
-        editData: {
-          completionStatus: CompletionStatus.REVIEW,
-        },
-      })
-
-      toast.success('Request for review successfully sent.')
-      onClose()
-    } catch (error: unknown) {
-      handleMutationError(error, 'request review')
-    }
-  }
-
-  async function overrideStage(e: React.MouseEvent<HTMLButtonElement>) {
-    try {
-      assertUserId()
-      e.preventDefault()
-      const response = await editCardMutation.mutateAsync({
-        activity: activity.name,
-        cardId: card.cardId,
-        editData: {
-          stage: newStage,
-        },
-      })
-      toast.success('Successfully overrode status.')
-      getCardDetails(response.data.details)
-      onClose()
-    } catch (error: unknown) {
-      handleMutationError(error, 'override card stage')
-    }
-  }
-
-  async function submitEditStage(newStageStatus: boolean) {
-    try {
-      assertUserId()
-      await editCardStageMutation.mutateAsync({
-        activity: activity.name,
-        cardId: card.cardId,
-        editData: {
-          stage: card.stage,
-          promote: newStageStatus,
-        },
-      })
-      toast.success('Successfully edited status.')
-      onClose()
-    } catch (error: unknown) {
-      handleMutationError(error, 'update card status')
-    }
-  }
-
-  async function removeCard() {
-    try {
-      assertUserId()
-      await deleteCardMutation.mutateAsync([
-        {
-          activity: activity.name,
-          cardId: card.cardId,
-        },
-      ])
-      toast.success('Successfully removed card')
-      onClose()
-    } catch (error: unknown) {
-      handleMutationError(error, 'remove card')
-    }
-  }
-
-  async function activate() {
-    try {
-      assertUserId()
-      await activateCardMutation.mutateAsync({
-        activity: activity.name,
-        cardId: card.cardId,
-      })
-      toast.success('Successfully activated card')
-      onClose()
-    } catch (error: unknown) {
-      handleMutationError(error, 'activate card')
-    }
-  }
+  const card = item!.card
+  const {
+    resetStage,
+    submitForReview,
+    overrideStage,
+    submitEditStage,
+    removeCard,
+    activate,
+    newStage,
+    setNewStage,
+  } = useCardActions(userId, activity, card, user, onClose)
 
   function formatCardInstructions(cardName: string) {
     if (cardName.includes(CARD_ACTIVITY_TYPES.VOCAB)) {
@@ -249,9 +116,9 @@ export default function ManageCardPopup({
                   <hr />
                   <div data-testid="card-owner-info" className="my-5">
                     <h6>
-                      Owner: {userInfo.firstName} {userInfo.lastName}
+                      Owner: {user?.firstName} {user?.lastName}
                     </h6>
-                    <h6>Activity: {activity.name}</h6>
+                    <h6>Activity: {activity?.name}</h6>
                     <h6>Created On: {card.addedOn}</h6>
                     <h6>Last updated: {card.lastUpdatedOn || 'Never'}</h6>
                     <h6>Next show date: {card.nextShowDate || 'Never'}</h6>
@@ -285,8 +152,8 @@ export default function ManageCardPopup({
                     )}
                   </div>
                 </div>
-                {((isMain && userInfo?.accountType === 'teacher') ||
-                  (!isMain && userInfo?.accountType === 'student')) &&
+                {((isMain && user?.accountType === 'teacher') ||
+                  (!isMain && user?.accountType === 'student')) &&
                   item?.action === 'override' && (
                     <div className="delete-actions mt-5">
                       <button
@@ -300,8 +167,8 @@ export default function ManageCardPopup({
                       </button>
                     </div>
                   )}
-                {((isMain && userInfo?.accountType === 'teacher') ||
-                  (!isMain && userInfo?.accountType === 'student')) &&
+                {((isMain && user?.accountType === 'teacher') ||
+                  (!isMain && user?.accountType === 'student')) &&
                   item?.action === 'delete' && (
                     <div className="delete-actions mt-5">
                       <button
@@ -315,8 +182,8 @@ export default function ManageCardPopup({
                       </button>
                     </div>
                   )}
-                {((isMain && userInfo?.accountType === 'teacher') ||
-                  (!isMain && userInfo?.accountType === 'student')) &&
+                {((isMain && user?.accountType === 'teacher') ||
+                  (!isMain && user?.accountType === 'student')) &&
                   item?.action === 'activate' && (
                     <div className="activate-actions mt-5">
                       <button
@@ -330,8 +197,8 @@ export default function ManageCardPopup({
                       </button>
                     </div>
                   )}
-                {((isMain && userInfo?.accountType === 'teacher') ||
-                  (!isMain && userInfo?.accountType === 'student')) &&
+                {((isMain && user?.accountType === 'teacher') ||
+                  (!isMain && user?.accountType === 'student')) &&
                   item?.action === 'edit' && (
                     <div className="teacher-actions">
                       <button
@@ -367,7 +234,7 @@ export default function ManageCardPopup({
                     </div>
                   )}
 
-                {isMain && userInfo?.accountType === 'student' && item?.action !== 'show' && (
+                {isMain && user?.accountType === 'student' && item?.action !== 'show' && (
                   <div className="student-actions">
                     <button
                       disabled={[CompletionStatus.COMPLETED, CompletionStatus.REVIEW].includes(

--- a/src/components/popups/manageCardPopup.tsx
+++ b/src/components/popups/manageCardPopup.tsx
@@ -20,12 +20,12 @@ export default function ManageCardPopup({
   onClose: () => void
   showModal: boolean
   isMain: boolean
-  user?: IUser | Partial<IUser>
-  activity?: IActivity
-  item?: { card: ICard; action: CardAction }
+  user: IUser | Partial<IUser>
+  activity: IActivity
+  item: { card: ICard; action: CardAction }
 }) {
-  const userId = user?.userId ?? ''
-  const card = item!.card
+  const userId = user.userId ?? ''
+  const card = item.card
   const {
     resetStage,
     submitForReview,
@@ -62,7 +62,7 @@ export default function ManageCardPopup({
   return (
     <>
       <div
-        data-testid={`manage-card-popup-${item?.action}`}
+        data-testid={`manage-card-popup-${item.action}`}
         aria-hidden="true"
         hidden={!showModal}
         id="popup-modal"
@@ -106,11 +106,11 @@ export default function ManageCardPopup({
                   Manage Card
                 </h3>
                 <div className="text-left">
-                  <h6 data-testid="card-name">{formatCardName(card.cardId, activity?.name)}</h6>
-                  {activity?.name !== ACTIVITY_TYPES.QURAN && (
+                  <h6 data-testid="card-name">{formatCardName(card.cardId, activity.name)}</h6>
+                  {activity.name !== ACTIVITY_TYPES.QURAN && (
                     <h6 data-testid="card-instructions">
                       Instructions:{' '}
-                      {formatCardInstructions(formatCardName(card.cardId, activity?.name))}
+                      {formatCardInstructions(formatCardName(card.cardId, activity.name))}
                     </h6>
                   )}
                   <hr />
@@ -118,7 +118,7 @@ export default function ManageCardPopup({
                     <h6>
                       Owner: {user?.firstName} {user?.lastName}
                     </h6>
-                    <h6>Activity: {activity?.name}</h6>
+                    <h6>Activity: {activity.name}</h6>
                     <h6>Created On: {card.addedOn}</h6>
                     <h6>Last updated: {card.lastUpdatedOn || 'Never'}</h6>
                     <h6>Next show date: {card.nextShowDate || 'Never'}</h6>
@@ -126,7 +126,7 @@ export default function ManageCardPopup({
                   <hr />
                   <div data-testid="card-stage-management" className="my-5">
                     <h6 className="mb-2">Current status: {card.completionStatus}</h6>
-                    {item?.action === 'override' ? (
+                    {item.action === 'override' ? (
                       <form className="max-w-md mx-auto" onChange={handleOverrideFormChange}>
                         <label
                           htmlFor="countries"
@@ -154,7 +154,7 @@ export default function ManageCardPopup({
                 </div>
                 {((isMain && user?.accountType === 'teacher') ||
                   (!isMain && user?.accountType === 'student')) &&
-                  item?.action === 'override' && (
+                  item.action === 'override' && (
                     <div className="delete-actions mt-5">
                       <button
                         data-testid="override-stage-btn"
@@ -169,7 +169,7 @@ export default function ManageCardPopup({
                   )}
                 {((isMain && user?.accountType === 'teacher') ||
                   (!isMain && user?.accountType === 'student')) &&
-                  item?.action === 'delete' && (
+                  item.action === 'delete' && (
                     <div className="delete-actions mt-5">
                       <button
                         data-testid="delete-card-btn"
@@ -184,7 +184,7 @@ export default function ManageCardPopup({
                   )}
                 {((isMain && user?.accountType === 'teacher') ||
                   (!isMain && user?.accountType === 'student')) &&
-                  item?.action === 'activate' && (
+                  item.action === 'activate' && (
                     <div className="activate-actions mt-5">
                       <button
                         data-testid="activate-card-btn"
@@ -199,7 +199,7 @@ export default function ManageCardPopup({
                   )}
                 {((isMain && user?.accountType === 'teacher') ||
                   (!isMain && user?.accountType === 'student')) &&
-                  item?.action === 'edit' && (
+                  item.action === 'edit' && (
                     <div className="teacher-actions">
                       <button
                         data-testid="reset-stage-btn"
@@ -234,7 +234,7 @@ export default function ManageCardPopup({
                     </div>
                   )}
 
-                {isMain && user?.accountType === 'student' && item?.action !== 'show' && (
+                {isMain && user?.accountType === 'student' && item.action !== 'show' && (
                   <div className="student-actions">
                     <button
                       disabled={[CompletionStatus.COMPLETED, CompletionStatus.REVIEW].includes(

--- a/src/components/popups/unlinkAccountPopup.tsx
+++ b/src/components/popups/unlinkAccountPopup.tsx
@@ -12,16 +12,16 @@ export default function UnlinkAccountPopup({
 }: {
   onClose: () => void
   showModal: boolean
-  user?: IUser | Partial<IUser>
-  teacherId?: string
+  user: IUser | Partial<IUser>
+  teacherId: string
 }) {
-  const resolvedTeacherId = teacherId ?? ''
+  const resolvedTeacherId = teacherId
   const unlinkStudentMutation = useUnlinkStudent(resolvedTeacherId)
 
   async function removeOldStudent() {
     try {
       if (!resolvedTeacherId) throw new Error('Missing teacherId for unlinkStudent')
-      await unlinkStudentMutation.mutateAsync(user!.userId!)
+      await unlinkStudentMutation.mutateAsync(user.userId!)
       toast.success('Successfully removed student.')
       onClose()
     } catch (error: unknown) {
@@ -71,9 +71,7 @@ export default function UnlinkAccountPopup({
                   Are you sure you want to remove this student?
                 </h3>
                 <h5 className="mb-5">
-                  <span>
-                    {`${user!.username!.split('-').join(' ')} - ${atob(user!.userId!)} `}{' '}
-                  </span>
+                  <span>{`${user.username!.split('-').join(' ')} - ${atob(user.userId!)} `} </span>
                 </h5>
               </div>
 

--- a/src/components/popups/unlinkAccountPopup.tsx
+++ b/src/components/popups/unlinkAccountPopup.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { useUnlinkStudent } from '@/hooks/use-student-mutations'
 import { IUser } from '@/types/IUser'
 import { XMarkIcon, MinusIcon } from '@heroicons/react/24/solid'
@@ -19,16 +18,10 @@ export default function UnlinkAccountPopup({
   const resolvedTeacherId = teacherId ?? ''
   const unlinkStudentMutation = useUnlinkStudent(resolvedTeacherId)
 
-  const [studentInfo, getStudentInfo] = useState<IUser | Partial<IUser>>({ ...user })
-
-  useEffect(() => {
-    getStudentInfo({ ...user })
-  }, [showModal, user])
-
   async function removeOldStudent() {
     try {
       if (!resolvedTeacherId) throw new Error('Missing teacherId for unlinkStudent')
-      await unlinkStudentMutation.mutateAsync(studentInfo.userId!)
+      await unlinkStudentMutation.mutateAsync(user!.userId!)
       toast.success('Successfully removed student.')
       onClose()
     } catch (error: unknown) {
@@ -79,7 +72,7 @@ export default function UnlinkAccountPopup({
                 </h3>
                 <h5 className="mb-5">
                   <span>
-                    {`${studentInfo!.username!.split('-').join(' ')} - ${atob(studentInfo!.userId!)} `}{' '}
+                    {`${user!.username!.split('-').join(' ')} - ${atob(user!.userId!)} `}{' '}
                   </span>
                 </h5>
               </div>

--- a/src/components/popups/validatePopup.tsx
+++ b/src/components/popups/validatePopup.tsx
@@ -9,11 +9,11 @@ export default function ValidatePopup({
 }: {
   onClose: () => void
   showModal: boolean
-  item?: { list: string }
-  submitList?: (list: string) => void
+  item: { list: string }
+  submitList: (list: string) => void
 }) {
   function validate() {
-    submitList?.(item!.list)
+    submitList(item.list)
     onClose()
   }
 
@@ -65,7 +65,7 @@ export default function ValidatePopup({
                   Is this the correct list of cards you want to create?
                 </h3>
                 <h5 className="mb-5">
-                  <span>{item?.list} </span>
+                  <span>{item.list} </span>
                 </h5>
               </div>
 

--- a/src/components/popups/validatePopup.tsx
+++ b/src/components/popups/validatePopup.tsx
@@ -1,5 +1,4 @@
 import { CheckBadgeIcon, XMarkIcon } from '@heroicons/react/24/solid'
-import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 export default function ValidatePopup({
@@ -13,14 +12,8 @@ export default function ValidatePopup({
   item?: { list: string }
   submitList?: (list: string) => void
 }) {
-  const [itemsToValidate, getItemsToValidate] = useState('')
-
-  useEffect(() => {
-    getItemsToValidate(item!.list)
-  }, [showModal, item])
-
   function validate() {
-    submitList?.(itemsToValidate)
+    submitList?.(item!.list)
     onClose()
   }
 
@@ -72,7 +65,7 @@ export default function ValidatePopup({
                   Is this the correct list of cards you want to create?
                 </h3>
                 <h5 className="mb-5">
-                  <span>{itemsToValidate} </span>
+                  <span>{item?.list} </span>
                 </h5>
               </div>
 

--- a/src/hooks/use-card-actions.ts
+++ b/src/hooks/use-card-actions.ts
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+import {
+  useEditCard,
+  useEditCardStage,
+  useResetCardStage,
+  useActivateCard,
+  useDeleteCard,
+  useRequestCardReview,
+} from '@/hooks/use-card-mutations'
+import { ICard } from '@/types/ICard'
+import { IUser } from '@/types/IUser'
+import { IActivity } from '@/types/IActivity'
+import { CompletionStatus } from '@/types/CompletionStatusEnum'
+import { toast } from 'sonner'
+import { handleMutationError } from '@/lib/helpers/mutation-error-handler'
+
+export function useCardActions(
+  userId: string,
+  activity: IActivity | undefined,
+  card: ICard | undefined,
+  user: IUser | Partial<IUser> | undefined,
+  onClose: () => void
+) {
+  const editCardMutation = useEditCard(userId)
+  const editCardStageMutation = useEditCardStage(userId)
+  const resetCardStageMutation = useResetCardStage(userId)
+  const activateCardMutation = useActivateCard(userId)
+  const deleteCardMutation = useDeleteCard(userId)
+  const requestReviewMutation = useRequestCardReview()
+
+  const [newStage, setNewStage] = useState('')
+
+  function assertUserId() {
+    if (!userId) throw new Error('Missing userId for card mutation')
+  }
+
+  async function resetStage() {
+    try {
+      assertUserId()
+      await resetCardStageMutation.mutateAsync({
+        activity: activity!.name,
+        cardId: card!.cardId,
+      })
+      toast.success('Successfully reset card')
+      onClose()
+    } catch (error: unknown) {
+      handleMutationError(error, 'reset card')
+    }
+  }
+
+  async function submitForReview() {
+    try {
+      assertUserId()
+      const requestReview = {
+        id: card!.cardId,
+        teacherId: user!.linkedAccountsData!.teacher!,
+        student: {
+          id: user!.userId!,
+          fullName: `${user!.firstName} ${user!.lastName}`,
+          email: user!.email!,
+        },
+      }
+
+      await requestReviewMutation.mutateAsync(requestReview)
+
+      await editCardStageMutation.mutateAsync({
+        activity: activity!.name,
+        cardId: card!.cardId,
+        editData: {
+          completionStatus: CompletionStatus.REVIEW,
+        },
+      })
+
+      toast.success('Request for review successfully sent.')
+      onClose()
+    } catch (error: unknown) {
+      handleMutationError(error, 'request review')
+    }
+  }
+
+  async function overrideStage(e: React.MouseEvent<HTMLButtonElement>) {
+    try {
+      assertUserId()
+      e.preventDefault()
+      await editCardMutation.mutateAsync({
+        activity: activity!.name,
+        cardId: card!.cardId,
+        editData: {
+          stage: newStage,
+        },
+      })
+      toast.success('Successfully overrode status.')
+      onClose()
+    } catch (error: unknown) {
+      handleMutationError(error, 'override card stage')
+    }
+  }
+
+  async function submitEditStage(newStageStatus: boolean) {
+    try {
+      assertUserId()
+      await editCardStageMutation.mutateAsync({
+        activity: activity!.name,
+        cardId: card!.cardId,
+        editData: {
+          stage: card!.stage,
+          promote: newStageStatus,
+        },
+      })
+      toast.success('Successfully edited status.')
+      onClose()
+    } catch (error: unknown) {
+      handleMutationError(error, 'update card status')
+    }
+  }
+
+  async function removeCard() {
+    try {
+      assertUserId()
+      await deleteCardMutation.mutateAsync([
+        {
+          activity: activity!.name,
+          cardId: card!.cardId,
+        },
+      ])
+      toast.success('Successfully removed card')
+      onClose()
+    } catch (error: unknown) {
+      handleMutationError(error, 'remove card')
+    }
+  }
+
+  async function activate() {
+    try {
+      assertUserId()
+      await activateCardMutation.mutateAsync({
+        activity: activity!.name,
+        cardId: card!.cardId,
+      })
+      toast.success('Successfully activated card')
+      onClose()
+    } catch (error: unknown) {
+      handleMutationError(error, 'activate card')
+    }
+  }
+
+  return {
+    resetStage,
+    submitForReview,
+    overrideStage,
+    submitEditStage,
+    removeCard,
+    activate,
+    newStage,
+    setNewStage,
+  }
+}

--- a/src/hooks/use-card-actions.ts
+++ b/src/hooks/use-card-actions.ts
@@ -16,9 +16,9 @@ import { handleMutationError } from '@/lib/helpers/mutation-error-handler'
 
 export function useCardActions(
   userId: string,
-  activity: IActivity | undefined,
-  card: ICard | undefined,
-  user: IUser | Partial<IUser> | undefined,
+  activity: IActivity,
+  card: ICard,
+  user: IUser | Partial<IUser>,
   onClose: () => void
 ) {
   const editCardMutation = useEditCard(userId)
@@ -38,8 +38,8 @@ export function useCardActions(
     try {
       assertUserId()
       await resetCardStageMutation.mutateAsync({
-        activity: activity!.name,
-        cardId: card!.cardId,
+        activity: activity.name,
+        cardId: card.cardId,
       })
       toast.success('Successfully reset card')
       onClose()
@@ -52,20 +52,20 @@ export function useCardActions(
     try {
       assertUserId()
       const requestReview = {
-        id: card!.cardId,
-        teacherId: user!.linkedAccountsData!.teacher!,
+        id: card.cardId,
+        teacherId: user.linkedAccountsData!.teacher!,
         student: {
-          id: user!.userId!,
-          fullName: `${user!.firstName} ${user!.lastName}`,
-          email: user!.email!,
+          id: user.userId!,
+          fullName: `${user.firstName} ${user.lastName}`,
+          email: user.email!,
         },
       }
 
       await requestReviewMutation.mutateAsync(requestReview)
 
       await editCardStageMutation.mutateAsync({
-        activity: activity!.name,
-        cardId: card!.cardId,
+        activity: activity.name,
+        cardId: card.cardId,
         editData: {
           completionStatus: CompletionStatus.REVIEW,
         },
@@ -83,8 +83,8 @@ export function useCardActions(
       assertUserId()
       e.preventDefault()
       await editCardMutation.mutateAsync({
-        activity: activity!.name,
-        cardId: card!.cardId,
+        activity: activity.name,
+        cardId: card.cardId,
         editData: {
           stage: newStage,
         },
@@ -100,10 +100,10 @@ export function useCardActions(
     try {
       assertUserId()
       await editCardStageMutation.mutateAsync({
-        activity: activity!.name,
-        cardId: card!.cardId,
+        activity: activity.name,
+        cardId: card.cardId,
         editData: {
-          stage: card!.stage,
+          stage: card.stage,
           promote: newStageStatus,
         },
       })
@@ -119,8 +119,8 @@ export function useCardActions(
       assertUserId()
       await deleteCardMutation.mutateAsync([
         {
-          activity: activity!.name,
-          cardId: card!.cardId,
+          activity: activity.name,
+          cardId: card.cardId,
         },
       ])
       toast.success('Successfully removed card')
@@ -134,8 +134,8 @@ export function useCardActions(
     try {
       assertUserId()
       await activateCardMutation.mutateAsync({
-        activity: activity!.name,
-        cardId: card!.cardId,
+        activity: activity.name,
+        cardId: card.cardId,
       })
       toast.success('Successfully activated card')
       onClose()

--- a/src/hooks/use-card-filtering.ts
+++ b/src/hooks/use-card-filtering.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react'
+import { ICard } from '@/types/ICard'
+import { IUser } from '@/types/IUser'
+import { IActivity } from '@/types/IActivity'
+import { CompletionStatus } from '@/types/CompletionStatusEnum'
+
+export function useCardFiltering(
+  activity: IActivity | undefined,
+  userDetails: IUser,
+  mounted: boolean | undefined
+) {
+  const [cardsOfTheDay, setCardsOfTheDay] = useState<ICard[]>([])
+  const [allActiveCards, setAllActiveCards] = useState<ICard[]>([])
+  const [allInactiveCards, setAllInactiveCards] = useState<ICard[]>([])
+  const [hash, setHash] = useState('')
+
+  useEffect(() => {
+    const cards: any[] | ICard = activity?.cards || []
+
+    if (cards.length) {
+      cards.map((card) => {
+        let num = `${atob(card.cardId).split('-')[1]}`
+        if (num.length === 1) {
+          card.number = `00${num}`
+        } else if (num.length === 2) {
+          card.number = `0${num}`
+        } else {
+          card.number = `${num}`
+        }
+      })
+      cards.sort((a, b) => a.number - b.number)
+      cards.map((card) => delete card.number)
+    }
+
+    const todayCards = cards?.filter((card) => {
+      return (
+        card.completionStatus === CompletionStatus.REVIEW ||
+        (card.completionStatus !== CompletionStatus.INACTIVE &&
+          card.completionStatus !== CompletionStatus.COMPLETED &&
+          (new Date().toLocaleDateString('en-US', { timeZone: 'EST' }) === card.nextShowDate ||
+            new Date().toLocaleDateString('en-US', { timeZone: 'EST' }) === card.addedOn))
+      )
+    })
+    setCardsOfTheDay(todayCards)
+
+    const activeCards = cards?.filter((card) => card.completionStatus !== CompletionStatus.INACTIVE)
+    setAllActiveCards(activeCards)
+
+    const inactiveCards = cards?.filter(
+      (card) => card.completionStatus === CompletionStatus.INACTIVE
+    )
+    setAllInactiveCards(inactiveCards)
+
+    if (mounted) {
+      const hashReducer = window.location.hash
+      setHash(hashReducer)
+    }
+  }, [userDetails, activity, mounted])
+
+  return { cardsOfTheDay, allActiveCards, allInactiveCards, hash }
+}

--- a/src/hooks/use-card-filtering.ts
+++ b/src/hooks/use-card-filtering.ts
@@ -1,14 +1,9 @@
 import { useState, useEffect } from 'react'
 import { ICard } from '@/types/ICard'
-import { IUser } from '@/types/IUser'
 import { IActivity } from '@/types/IActivity'
 import { CompletionStatus } from '@/types/CompletionStatusEnum'
 
-export function useCardFiltering(
-  activity: IActivity | undefined,
-  userDetails: IUser,
-  mounted: boolean | undefined
-) {
+export function useCardFiltering(activity: IActivity | undefined, mounted: boolean | undefined) {
   const [cardsOfTheDay, setCardsOfTheDay] = useState<ICard[]>([])
   const [allActiveCards, setAllActiveCards] = useState<ICard[]>([])
   const [allInactiveCards, setAllInactiveCards] = useState<ICard[]>([])
@@ -55,7 +50,7 @@ export function useCardFiltering(
       const hashReducer = window.location.hash
       setHash(hashReducer)
     }
-  }, [userDetails, activity, mounted])
+  }, [activity, mounted])
 
   return { cardsOfTheDay, allActiveCards, allInactiveCards, hash }
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor card management and popup components to extract reusable hooks and remove redundant local state derived from props.

Enhancements:
- Extract shared card mutation logic into a reusable useCardActions hook used by the manage card popup.
- Extract card filtering and sorting logic into a reusable useCardFiltering hook used by the cards list.
- Simplify multiple popup components to rely directly on props instead of syncing derived local state, reducing props-to-state anti-pattern usage.