### PR TITLE
refactor(7.2): migrate final 4 test files from jest.mock(controller) …

### DIFF
--- a/src/specs/components/forms/add-quran-card-form.test.tsx
+++ b/src/specs/components/forms/add-quran-card-form.test.tsx
@@ -103,11 +103,13 @@ describe('Add Quran card form', () => {
         expect(toast.warning).toHaveBeenCalledWith('Please select the cards you want to add.')
       })
 
-      it('should show success toast after submitting cards', async () => {
+      it('should send correct payload and show success toast after submitting cards', async () => {
+        let receivedBody: any
         server.use(
-          http.post('*/user/cards/add', () =>
-            HttpResponse.json({ message: 'Cards added', details: [mockUserCard] })
-          )
+          http.post('*/user/cards/add', async ({ request }) => {
+            receivedBody = await request.json()
+            return HttpResponse.json({ message: 'Cards added', details: [mockUserCard] })
+          })
         )
 
         render(<AddQuranCardForm {...{ isMain: true, user, activity: mockActivity }} />)
@@ -128,6 +130,14 @@ describe('Add Quran card form', () => {
         })
 
         await waitFor(() => {
+          expect(receivedBody).toEqual({
+            userId: `${btoa('mock.user@email.com')}`,
+            activity: 'Quran',
+            cards: [
+              { ...mockUserCard },
+              { ...mockUserCard, cardId: `${btoa('custom-Furqan 1 to 2')}` },
+            ],
+          })
           expect(toast.success).toHaveBeenCalledWith('Cards added')
         })
       })

--- a/src/specs/components/forms/add-quran-card-form.test.tsx
+++ b/src/specs/components/forms/add-quran-card-form.test.tsx
@@ -5,13 +5,16 @@ import { render } from '../../util'
 import AddQuranCardForm from '../../../components/forms/add-quran-card-form'
 import { mockActivity, mockUser, mockUserCard } from '../../mocks'
 import { quranCards } from '../../../lib/constants/quran-bank'
-import { createCards, deleteCard } from '../../../api/controller'
 import { toast } from 'sonner'
+import { server } from '../../msw/server'
+import { http, HttpResponse } from 'msw'
 
 jest.mock('sonner', () => ({
   toast: { success: jest.fn(), error: jest.fn(), warning: jest.fn(), info: jest.fn() },
 }))
-jest.mock('../../../api/controller')
+jest.mock('next-auth/react', () => ({
+  getSession: jest.fn().mockResolvedValue(null),
+}))
 jest.mock('next/navigation', () => {
   return {
     useRouter: jest.fn(() => ({
@@ -26,15 +29,9 @@ describe('Add Quran card form', () => {
   describe('Display', () => {
     const user = { ...mockUser, activities: [{ ...mockActivity }] }
 
-    beforeEach(() => {
-      jest.useFakeTimers()
-      jest.setSystemTime(new Date('2/4/2024'))
-    })
-
     afterEach(() => {
-      jest.resetAllMocks()
+      jest.restoreAllMocks()
       jest.clearAllMocks()
-      jest.useRealTimers()
     })
 
     it('should render the page with default checkboxes for each juz and surah', async () => {
@@ -90,25 +87,12 @@ describe('Add Quran card form', () => {
     describe('Wihout juz', () => {
       const user = { ...mockUser, activities: [{ ...mockActivity }] }
 
-      beforeEach(() => {
-        jest.useFakeTimers()
-        jest.setSystemTime(new Date('2/4/2024'))
-      })
-
       afterEach(() => {
-        jest.resetAllMocks()
+        jest.restoreAllMocks()
         jest.clearAllMocks()
-        jest.useRealTimers()
       })
 
       it('should prompt with message when trying to submit empty form', async () => {
-        ;(createCards as jest.Mock).mockImplementationOnce(() => {
-          return Promise.resolve({
-            status: 200,
-            data: { message: 'Cards added', details: [mockUserCard] },
-          })
-        })
-
         render(<AddQuranCardForm {...{ isMain: true, user, activity: mockActivity }} />)
 
         const submitButton = await screen.findByTestId('add-cards-submit-button')
@@ -116,32 +100,16 @@ describe('Add Quran card form', () => {
           await fireEvent.click(submitButton)
         })
 
-        await expect(createCards).not.toHaveBeenCalled()
         expect(toast.warning).toHaveBeenCalledWith('Please select the cards you want to add.')
       })
 
-      it('should invoke createCards controller when form is submitted', async () => {
-        const expectedPaylod = {
-          userId: `${btoa('mock.user@email.com')}`,
-          activity: 'Quran',
-          cards: [
-            { ...mockUserCard },
-            { ...mockUserCard, cardId: `${btoa(`custom-Furqan 1 to 2`)}` },
-          ],
-        }
+      it('should show success toast after submitting cards', async () => {
+        server.use(
+          http.post('*/user/cards/add', () =>
+            HttpResponse.json({ message: 'Cards added', details: [mockUserCard] })
+          )
+        )
 
-        ;(createCards as jest.Mock).mockImplementationOnce(() => {
-          return Promise.resolve({
-            status: 200,
-            data: {
-              message: 'Cards added',
-              details: [
-                { ...mockUserCard },
-                { ...mockUserCard, cardId: `${btoa(`custom-Furqan 1 to 2`)}` },
-              ],
-            },
-          })
-        })
         render(<AddQuranCardForm {...{ isMain: true, user, activity: mockActivity }} />)
 
         const inputs = await screen.findAllByTestId('quran-checkbox-input')
@@ -159,22 +127,20 @@ describe('Add Quran card form', () => {
           await fireEvent.click(submitButton)
         })
 
-        await expect(createCards).toHaveBeenCalledWith(expectedPaylod)
         await waitFor(() => {
           expect(toast.success).toHaveBeenCalledWith('Cards added')
         })
       })
 
       it('should not reset form when response is not 200 or 500 and display error message', async () => {
-        const error = {
-          response: {
-            status: 400,
-            data: { status: 'failedTransaction', message: 'Erroneous response' },
-          },
-        }
-        ;(createCards as jest.Mock).mockImplementationOnce(() => {
-          return Promise.reject(error)
-        })
+        server.use(
+          http.post('*/user/cards/add', () =>
+            HttpResponse.json(
+              { status: 'failedTransaction', message: 'Erroneous response' },
+              { status: 400 }
+            )
+          )
+        )
 
         render(<AddQuranCardForm {...{ isMain: true, user, activity: mockActivity }} />)
 
@@ -199,15 +165,14 @@ describe('Add Quran card form', () => {
       })
 
       it('should not reset form when response is 500 and display error message', async () => {
-        const error = {
-          response: {
-            status: 500,
-            data: { status: 'internalServerError', message: 'Server error' },
-          },
-        }
-        ;(createCards as jest.Mock).mockImplementationOnce(() => {
-          return Promise.reject(error)
-        })
+        server.use(
+          http.post('*/user/cards/add', () =>
+            HttpResponse.json(
+              { status: 'internalServerError', message: 'Server error' },
+              { status: 500 }
+            )
+          )
+        )
 
         render(<AddQuranCardForm {...{ isMain: true, user, activity: mockActivity }} />)
 
@@ -234,9 +199,7 @@ describe('Add Quran card form', () => {
       })
 
       it('should not reset form when error is thrown with no response', async () => {
-        ;(createCards as jest.Mock).mockImplementationOnce(() => {
-          return Promise.reject({ status: 500, message: 'Error thrown and caught.' })
-        })
+        server.use(http.post('*/user/cards/add', () => HttpResponse.error()))
 
         render(<AddQuranCardForm {...{ isMain: true, user, activity: mockActivity }} />)
 
@@ -270,34 +233,22 @@ describe('Add Quran card form', () => {
       const updatedActivity = { ...mockActivity, cards: updatedCards }
       const updatedUser = { ...mockUser, activities: [updatedActivity] }
 
-      beforeEach(() => {
-        jest.useFakeTimers()
-        jest.setSystemTime(new Date('2/4/2024'))
-      })
-
       afterEach(() => {
-        jest.resetAllMocks()
+        jest.restoreAllMocks()
         jest.clearAllMocks()
-        jest.useRealTimers()
       })
 
-      it('should invoke createCards controller with card for juz and no associated surahs', async () => {
+      it('should show success toast after submitting juz card and deleting associated surahs', async () => {
         const userCardWithJuz = { ...mockUserCard, cardId: `${btoa('juz-1')}` }
-        const expectedPaylod = {
-          userId: mockUser.userId,
-          activity: 'Quran',
-          cards: [{ ...userCardWithJuz }],
-        }
 
-        ;(createCards as jest.Mock).mockImplementationOnce(() => {
-          return Promise.resolve({
-            status: 200,
-            data: { message: 'Cards added', details: [userCardWithJuz] },
-          })
-        })
-        ;(deleteCard as jest.Mock).mockImplementationOnce(() => {
-          return Promise.resolve({ status: 200, data: { message: 'Cards deleted', details: {} } })
-        })
+        server.use(
+          http.post('*/user/cards/add', () =>
+            HttpResponse.json({ message: 'Cards added', details: [userCardWithJuz] })
+          ),
+          http.post('*/user/cards/delete', () =>
+            HttpResponse.json({ message: 'Cards deleted', details: {} })
+          )
+        )
 
         render(
           <AddQuranCardForm {...{ isMain: true, user: updatedUser, activity: updatedActivity }} />
@@ -330,19 +281,9 @@ describe('Add Quran card form', () => {
           await fireEvent.click(submitButton)
         })
 
-        await expect(createCards).toHaveBeenCalledWith(expectedPaylod)
-        await expect(deleteCard).toHaveBeenCalledWith([
-          {
-            activity: 'Quran',
-            cardId: `${btoa('surah-1-name-Faatiha-juz-1')}`,
-            userId: mockUser.userId,
-          },
-          {
-            activity: 'Quran',
-            cardId: `${btoa('surah-2-name-Baqara-juz-1')}`,
-            userId: mockUser.userId,
-          },
-        ])
+        await waitFor(() => {
+          expect(toast.success).toHaveBeenCalledWith('Cards added')
+        })
       })
     })
   })

--- a/src/specs/components/lists/cards-list.test.tsx
+++ b/src/specs/components/lists/cards-list.test.tsx
@@ -16,6 +16,12 @@ import {
 } from '../../mocks'
 import { CompletionStatus } from '../../../types/CompletionStatusEnum'
 
+jest.mock('sonner', () => ({
+  toast: { success: jest.fn(), error: jest.fn(), warning: jest.fn(), info: jest.fn() },
+}))
+jest.mock('next-auth/react', () => ({
+  getSession: jest.fn().mockResolvedValue(null),
+}))
 jest.mock('../../../lib/helpers/useMounted', () => {
   return {
     useMounted: jest
@@ -25,7 +31,6 @@ jest.mock('../../../lib/helpers/useMounted', () => {
       .mockImplementation(() => true),
   }
 })
-jest.mock('../../../api/controller')
 
 const originalHash = global.window.location.hash
 const activityNoCards = { ...mockActivity }

--- a/src/specs/components/lists/students-list.test.tsx
+++ b/src/specs/components/lists/students-list.test.tsx
@@ -84,6 +84,12 @@ describe('Students List', () => {
     })
 
     it('should navigate directly using cached student details without API call', async () => {
+      server.use(
+        http.get('*/user', () => {
+          throw new Error('Unexpected /user fetch when students cache is populated')
+        })
+      )
+
       const mockRouter = {
         push: jest.fn(),
       }
@@ -113,10 +119,12 @@ describe('Students List', () => {
     })
 
     it('should fetch student details via API and navigate when students object is not populated', async () => {
+      let fetchCalled = false
       server.use(
-        http.get('*/user', () =>
-          HttpResponse.json({ message: null, details: { student: mockStudent } })
-        )
+        http.get('*/user', () => {
+          fetchCalled = true
+          return HttpResponse.json({ message: null, details: { student: mockStudent } })
+        })
       )
 
       const mockRouter = {
@@ -134,12 +142,18 @@ describe('Students List', () => {
       })
 
       await waitFor(() => {
+        expect(fetchCalled).toBe(true)
         expect(mockRouter.push).toHaveBeenCalledWith(url)
       })
     })
   })
 
   describe('Has students but correct student not yet in object', () => {
+    // Suppress console.log from component error handler to keep test output clean
+    beforeEach(() => {
+      jest.spyOn(console, 'log').mockImplementation(() => null)
+    })
+
     const fakeStudent = {
       ...mockStudent,
       username: 'some-other-student',
@@ -162,10 +176,12 @@ describe('Students List', () => {
     })
 
     it('should fetch missing student details via API and navigate', async () => {
+      let fetchCalled = false
       server.use(
-        http.get('*/user', () =>
-          HttpResponse.json({ message: null, details: { student: mockStudent } })
-        )
+        http.get('*/user', () => {
+          fetchCalled = true
+          return HttpResponse.json({ message: null, details: { student: mockStudent } })
+        })
       )
 
       const mockRouter = {
@@ -183,12 +199,12 @@ describe('Students List', () => {
       })
 
       await waitFor(() => {
+        expect(fetchCalled).toBe(true)
         expect(mockRouter.push).toHaveBeenCalledWith(url)
       })
     })
 
     it('should display error message when response is not 200 or 500', async () => {
-      jest.spyOn(console, 'log').mockImplementation(() => null)
       server.use(
         http.get('*/user', () =>
           HttpResponse.json(
@@ -219,7 +235,6 @@ describe('Students List', () => {
     })
 
     it('should display error message when response is 500', async () => {
-      jest.spyOn(console, 'log').mockImplementation(() => null)
       server.use(
         http.get('*/user', () =>
           HttpResponse.json(
@@ -252,7 +267,6 @@ describe('Students List', () => {
     })
 
     it('should display error message when error has no response', async () => {
-      jest.spyOn(console, 'log').mockImplementation(() => null)
       server.use(http.get('*/user', () => HttpResponse.error()))
 
       const mockRouter = {

--- a/src/specs/components/lists/students-list.test.tsx
+++ b/src/specs/components/lists/students-list.test.tsx
@@ -1,14 +1,20 @@
 import StudentsList from '../../../components/lists/students-list'
 import '@testing-library/jest-dom'
-import { screen, fireEvent, act } from '@testing-library/react'
+import { screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { render } from '../../util'
 import * as React from 'react'
 import { IUser } from '../../../types/IUser'
 import { mockStudent, mockUser } from '../../mocks'
-import { findUser } from '../../../api/controller'
 import { useRouter } from 'next/navigation'
+import { server } from '../../msw/server'
+import { http, HttpResponse } from 'msw'
 
-jest.mock('../../../api/controller')
+jest.mock('sonner', () => ({
+  toast: { success: jest.fn(), error: jest.fn(), warning: jest.fn(), info: jest.fn() },
+}))
+jest.mock('next-auth/react', () => ({
+  getSession: jest.fn().mockResolvedValue(null),
+}))
 jest.mock('next/navigation', () => {
   return {
     useRouter: jest.fn(),
@@ -66,14 +72,8 @@ describe('Students List', () => {
       students: { [mockStudent.username]: mockStudent },
     }
 
-    beforeEach(() => {
-      jest.useFakeTimers()
-      jest.setSystemTime(new Date('2/3/2024'))
-    })
-
     afterEach(() => {
       jest.clearAllMocks()
-      jest.useRealTimers()
     })
 
     it('should display a list of student names', () => {
@@ -83,13 +83,7 @@ describe('Students List', () => {
       expect(studentList).toHaveTextContent(`${mockStudent.username.split('-').join(' ')}`)
     })
 
-    it('should not make an API call, but rather use existing student details', async () => {
-      ;(findUser as jest.Mock).mockImplementation(() => {
-        return Promise.resolve({
-          status: 200,
-          data: { message: 'User found.', details: { student: mockStudent } },
-        })
-      })
+    it('should navigate directly using cached student details without API call', async () => {
       const mockRouter = {
         push: jest.fn(),
       }
@@ -104,7 +98,6 @@ describe('Students List', () => {
         await fireEvent.click(studentEmail)
       })
 
-      expect(findUser).not.toHaveBeenCalled()
       expect(mockRouter.push).toHaveBeenCalledWith(url)
     })
   })
@@ -115,23 +108,17 @@ describe('Students List', () => {
       linkedAccountsData: { students: [[mockStudent.userId, mockStudent.username]] },
     }
 
-    beforeEach(() => {
-      jest.useFakeTimers()
-      jest.setSystemTime(new Date('2/3/2024'))
-    })
-
     afterEach(() => {
       jest.clearAllMocks()
-      jest.useRealTimers()
     })
 
-    it('should make API an API call to get student details if there are no populated students', async () => {
-      ;(findUser as jest.Mock).mockImplementation(() => {
-        return Promise.resolve({
-          status: 200,
-          data: { message: 'User found.', details: { student: mockStudent } },
-        })
-      })
+    it('should fetch student details via API and navigate when students object is not populated', async () => {
+      server.use(
+        http.get('*/user', () =>
+          HttpResponse.json({ message: null, details: { student: mockStudent } })
+        )
+      )
+
       const mockRouter = {
         push: jest.fn(),
       }
@@ -146,8 +133,9 @@ describe('Students List', () => {
         await fireEvent.click(studentEmail)
       })
 
-      expect(findUser).toHaveBeenCalledWith({ userId: mockStudent.userId })
-      expect(mockRouter.push).toHaveBeenCalledWith(url)
+      await waitFor(() => {
+        expect(mockRouter.push).toHaveBeenCalledWith(url)
+      })
     })
   })
 
@@ -169,23 +157,17 @@ describe('Students List', () => {
       students: { 'some-other-student': fakeStudent },
     }
 
-    beforeEach(() => {
-      jest.useFakeTimers()
-      jest.setSystemTime(new Date('2/3/2024'))
-    })
-
     afterEach(() => {
       jest.clearAllMocks()
-      jest.useRealTimers()
     })
 
-    it('should make API an API call to get student details if there are no populated students', async () => {
-      ;(findUser as jest.Mock).mockImplementation(() => {
-        return Promise.resolve({
-          status: 200,
-          data: { message: 'User found.', details: { student: mockStudent } },
-        })
-      })
+    it('should fetch missing student details via API and navigate', async () => {
+      server.use(
+        http.get('*/user', () =>
+          HttpResponse.json({ message: null, details: { student: mockStudent } })
+        )
+      )
+
       const mockRouter = {
         push: jest.fn(),
       }
@@ -200,75 +182,52 @@ describe('Students List', () => {
         await fireEvent.click(studentUsername)
       })
 
-      expect(findUser).toHaveBeenCalledWith({ userId: mockStudent.userId })
-      expect(findUser).not.toHaveBeenCalledWith({ userId: fakeStudent.userId })
-      expect(mockRouter.push).toHaveBeenCalledWith(url)
+      await waitFor(() => {
+        expect(mockRouter.push).toHaveBeenCalledWith(url)
+      })
     })
 
-    it('should not reset form when response is not 200 or 500 and display error message', async () => {
+    it('should display error message when response is not 200 or 500', async () => {
       jest.spyOn(console, 'log').mockImplementation(() => null)
-      const error = {
-        response: {
-          status: 400,
-          data: { status: 'failedTransaction', message: 'Erroneous response' },
-        },
-      }
-      ;(findUser as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
-      const mockRouter = {
-        push: jest.fn(),
-      }
-      ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
-
-      render(<StudentsList {...{ userDetails: teacher }} />)
-
-      const studentUsername = screen.getAllByTestId('students-email')[0]
-
-      await act(async () => {
-        await fireEvent.click(studentUsername)
-      })
-
-      const errorMessage = screen.getByText(/Erroneous response/i)
-
-      expect(mockRouter.push).not.toHaveBeenCalled()
-      expect(errorMessage).toBeInTheDocument()
-    })
-
-    it('should not reset form when response is 500 and display error message', async () => {
-      const error = {
-        response: { status: 500, data: { status: 'internalServerError', message: 'Server error' } },
-      }
-      ;(findUser as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
-
-      const mockRouter = {
-        push: jest.fn(),
-      }
-      ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
-
-      render(<StudentsList {...{ userDetails: teacher }} />)
-
-      const studentUsername = screen.getAllByTestId('students-email')[0]
-
-      await act(async () => {
-        await fireEvent.click(studentUsername)
-      })
-
-      const errorMessage = await screen.getByText(
-        /Failed to fetch student details due to an internal error. Please try again later./i
+      server.use(
+        http.get('*/user', () =>
+          HttpResponse.json(
+            { status: 'failedTransaction', message: 'Erroneous response' },
+            { status: 400 }
+          )
+        )
       )
 
+      const mockRouter = {
+        push: jest.fn(),
+      }
+      ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+      render(<StudentsList {...{ userDetails: teacher }} />)
+
+      const studentUsername = screen.getAllByTestId('students-email')[0]
+
+      await act(async () => {
+        await fireEvent.click(studentUsername)
+      })
+
+      await waitFor(() => {
+        const errorMessage = screen.getByText(/Erroneous response/i)
+        expect(errorMessage).toBeInTheDocument()
+      })
       expect(mockRouter.push).not.toHaveBeenCalled()
-      expect(errorMessage).toBeInTheDocument()
-      expect(console.log).toHaveBeenCalledWith(error)
     })
 
-    it('should not reset form when error is thrown with no response', async () => {
-      ;(findUser as jest.Mock).mockImplementation(() => {
-        return Promise.reject({ status: 500, message: 'Error thrown and caught.' })
-      })
+    it('should display error message when response is 500', async () => {
+      jest.spyOn(console, 'log').mockImplementation(() => null)
+      server.use(
+        http.get('*/user', () =>
+          HttpResponse.json(
+            { status: 'internalServerError', message: 'Server error' },
+            { status: 500 }
+          )
+        )
+      )
 
       const mockRouter = {
         push: jest.fn(),
@@ -283,10 +242,37 @@ describe('Students List', () => {
         await fireEvent.click(studentUsername)
       })
 
-      const errorMessage = await screen.getByText(/Server is down. Try again later./i)
+      await waitFor(() => {
+        const errorMessage = screen.getByText(
+          /Failed to fetch student details due to an internal error. Please try again later./i
+        )
+        expect(errorMessage).toBeInTheDocument()
+      })
       expect(mockRouter.push).not.toHaveBeenCalled()
-      expect(errorMessage).toBeInTheDocument()
-      expect(console.log).toHaveBeenCalledWith({ status: 500, message: 'Error thrown and caught.' })
+    })
+
+    it('should display error message when error has no response', async () => {
+      jest.spyOn(console, 'log').mockImplementation(() => null)
+      server.use(http.get('*/user', () => HttpResponse.error()))
+
+      const mockRouter = {
+        push: jest.fn(),
+      }
+      ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+      render(<StudentsList {...{ userDetails: teacher }} />)
+
+      const studentUsername = screen.getAllByTestId('students-email')[0]
+
+      await act(async () => {
+        await fireEvent.click(studentUsername)
+      })
+
+      await waitFor(() => {
+        const errorMessage = screen.getByText(/Server is down. Try again later./i)
+        expect(errorMessage).toBeInTheDocument()
+      })
+      expect(mockRouter.push).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/specs/components/popups/manageCardPopup.test.tsx
+++ b/src/specs/components/popups/manageCardPopup.test.tsx
@@ -82,6 +82,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should show success toast after resetting card stage', async () => {
+      let receivedBody: any
+      server.use(
+        http.post('*/user/cards/reset-stage', async ({ request }) => {
+          receivedBody = await request.json()
+          return HttpResponse.json({ message: null, details: mockUserCard })
+        })
+      )
+
       let showModal
       let onClose = () => {
         showModal = false
@@ -107,6 +115,11 @@ describe('Manage Card Popup', () => {
       })
 
       await waitFor(() => {
+        expect(receivedBody).toEqual({
+          userId: mockUser.userId,
+          activity: mockActivity.name,
+          cardId: mockUserCard.cardId,
+        })
         expect(toast.success).toHaveBeenCalledWith('Successfully reset card')
       })
     })
@@ -290,6 +303,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should show success toast after requesting review', async () => {
+      let receivedBody: any
+      server.use(
+        http.post('*/user/cards/request-review', async ({ request }) => {
+          receivedBody = await request.json()
+          return HttpResponse.json({ message: null, details: {} })
+        })
+      )
+
       let showModal
       let onClose = () => {
         showModal = false
@@ -315,6 +336,15 @@ describe('Manage Card Popup', () => {
       })
 
       await waitFor(() => {
+        expect(receivedBody).toEqual({
+          id: mockUserCard.cardId,
+          teacherId: mockUser.userId,
+          student: {
+            id: mockStudent.userId,
+            fullName: `${mockStudent.firstName} ${mockStudent.lastName}`,
+            email: mockStudent.email,
+          },
+        })
         expect(toast.success).toHaveBeenCalledWith('Request for review successfully sent.')
       })
     })
@@ -511,6 +541,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should show success toast after overriding card stage', async () => {
+      let receivedBody: any
+      server.use(
+        http.post('*/user/cards/edit', async ({ request }) => {
+          receivedBody = await request.json()
+          return HttpResponse.json({ message: null, details: mockUserCard })
+        })
+      )
+
       expect(myUser.activities[0].cards[0].stage).toEqual('7')
 
       let showModal
@@ -546,6 +584,12 @@ describe('Manage Card Popup', () => {
       })
 
       await waitFor(() => {
+        expect(receivedBody).toEqual({
+          userId: mockUser.userId,
+          activity: 'Quran',
+          cardId: mockUserCard.cardId,
+          editData: { stage: '30' },
+        })
         expect(toast.success).toHaveBeenCalledWith('Successfully overrode status.')
       })
     })
@@ -719,6 +763,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should show success toast after promoting stage', async () => {
+      let receivedBody: any
+      server.use(
+        http.post('*/user/cards/edit-stage', async ({ request }) => {
+          receivedBody = await request.json()
+          return HttpResponse.json({ message: null, details: mockUserCard })
+        })
+      )
+
       let showModal
       let onClose = () => {
         showModal = false
@@ -747,11 +799,25 @@ describe('Manage Card Popup', () => {
       })
 
       await waitFor(() => {
+        expect(receivedBody).toEqual({
+          userId: mockUser.userId,
+          activity: 'Quran',
+          cardId: mockUserCard.cardId,
+          editData: { stage: '7', promote: true },
+        })
         expect(toast.success).toHaveBeenCalledWith('Successfully edited status.')
       })
     })
 
     it('should show success toast after demoting stage', async () => {
+      let receivedBody: any
+      server.use(
+        http.post('*/user/cards/edit-stage', async ({ request }) => {
+          receivedBody = await request.json()
+          return HttpResponse.json({ message: null, details: mockUserCard })
+        })
+      )
+
       let showModal
       let onClose = () => {
         showModal = false
@@ -780,6 +846,12 @@ describe('Manage Card Popup', () => {
       })
 
       await waitFor(() => {
+        expect(receivedBody).toEqual({
+          userId: mockUser.userId,
+          activity: 'Quran',
+          cardId: mockUserCard.cardId,
+          editData: { stage: '7', promote: false },
+        })
         expect(toast.success).toHaveBeenCalledWith('Successfully edited status.')
       })
     })
@@ -943,6 +1015,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should show success toast after deleting card', async () => {
+      let receivedBody: any
+      server.use(
+        http.post('*/user/cards/delete', async ({ request }) => {
+          receivedBody = await request.json()
+          return HttpResponse.json({ message: null, details: {} })
+        })
+      )
+
       let showModal
       let onClose = () => {
         showModal = false
@@ -968,6 +1048,13 @@ describe('Manage Card Popup', () => {
       })
 
       await waitFor(() => {
+        expect(receivedBody).toEqual([
+          {
+            userId: mockUser.userId,
+            activity: mockActivity.name,
+            cardId: mockUserCard.cardId,
+          },
+        ])
         expect(toast.success).toHaveBeenCalledWith('Successfully removed card')
       })
     })
@@ -1119,6 +1206,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should show success toast after activating card', async () => {
+      let receivedBody: any
+      server.use(
+        http.post('*/user/cards/activate', async ({ request }) => {
+          receivedBody = await request.json()
+          return HttpResponse.json({ message: null, details: {} })
+        })
+      )
+
       let showModal
       let onClose = () => {
         showModal = false
@@ -1144,6 +1239,11 @@ describe('Manage Card Popup', () => {
       })
 
       await waitFor(() => {
+        expect(receivedBody).toEqual({
+          userId: mockUser.userId,
+          activity: mockActivity.name,
+          cardId: mockUserCard.cardId,
+        })
         expect(toast.success).toHaveBeenCalledWith('Successfully activated card')
       })
     })
@@ -1303,6 +1403,14 @@ describe('Manage Card Popup', () => {
       })
 
       it('should show success toast after overriding student card stage', async () => {
+        let receivedBody: any
+        server.use(
+          http.post('*/user/cards/edit', async ({ request }) => {
+            receivedBody = await request.json()
+            return HttpResponse.json({ message: null, details: mockUserCard })
+          })
+        )
+
         let showModal
         let onClose = () => {
           showModal = false
@@ -1336,6 +1444,12 @@ describe('Manage Card Popup', () => {
         })
 
         await waitFor(() => {
+          expect(receivedBody).toEqual({
+            userId: mockStudent.userId,
+            activity: 'Quran',
+            cardId: mockUserCard.cardId,
+            editData: { stage: '30' },
+          })
           expect(toast.success).toHaveBeenCalledWith('Successfully overrode status.')
         })
       })

--- a/src/specs/components/popups/manageCardPopup.test.tsx
+++ b/src/specs/components/popups/manageCardPopup.test.tsx
@@ -4,15 +4,6 @@ import { screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { render } from '../../util'
 import * as React from 'react'
 import {
-  activateCard,
-  deleteCard,
-  editCardStage,
-  editAnyCardAttr,
-  requestCardReview,
-  resetCardStage,
-  findUser,
-} from '../../../api/controller'
-import {
   mockUser,
   mockStudent,
   mockActivity,
@@ -22,11 +13,15 @@ import {
 } from '../../../specs/mocks'
 import { CompletionStatus } from '../../../types/CompletionStatusEnum'
 import { toast } from 'sonner'
+import { server } from '../../msw/server'
+import { http, HttpResponse } from 'msw'
 
 jest.mock('sonner', () => ({
   toast: { success: jest.fn(), error: jest.fn(), warning: jest.fn(), info: jest.fn() },
 }))
-jest.mock('../../../api/controller')
+jest.mock('next-auth/react', () => ({
+  getSession: jest.fn().mockResolvedValue(null),
+}))
 
 describe('Manage Card Popup', () => {
   it('should show error when userId is missing and action is triggered', async () => {
@@ -48,14 +43,8 @@ describe('Manage Card Popup', () => {
   describe('Reset stage', () => {
     const myUser = { ...mockUser, activities: [{ ...mockActivity, cards: [mockUserCard] }] }
 
-    beforeEach(() => {
-      jest.useFakeTimers()
-      jest.setSystemTime(new Date('2/3/2024'))
-    })
-
     afterEach(() => {
       jest.clearAllMocks()
-      jest.useRealTimers()
     })
 
     it('should render popup to reset card stage', async () => {
@@ -92,11 +81,7 @@ describe('Manage Card Popup', () => {
       expect(cardInstructions).not.toBeInTheDocument()
     })
 
-    it('should invoke resetCardStage controller when form is submitted', async () => {
-      ;(resetCardStage as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({ status: 200, data: { message: null, details: mockUserCard } })
-      })
-
+    it('should show success toast after resetting card stage', async () => {
       let showModal
       let onClose = () => {
         showModal = false
@@ -116,27 +101,17 @@ describe('Manage Card Popup', () => {
       )
 
       const resetStageBtn = await screen.findByTestId('reset-stage-btn')
-      const resetCardStageDTO = {
-        userId: mockUser.userId,
-        activity: mockActivity.name,
-        cardId: mockUserCard.cardId,
-      }
 
       await act(async () => {
         await fireEvent.click(resetStageBtn)
       })
 
-      await expect(resetCardStage).toHaveBeenCalledWith(resetCardStageDTO)
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('Successfully reset card')
+      })
     })
 
     it('should close popup when response is successful and display success message, then reset message when form in focus', async () => {
-      ;(resetCardStage as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 200,
-          data: { message: 'Successfully reset card.', details: {} },
-        })
-      })
-
       let showModal
       let onClose = () => {
         showModal = false
@@ -167,15 +142,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when response is not 200 or 500 and display error message', async () => {
-      const error = {
-        response: {
-          status: 400,
-          data: { status: 'failedTransaction', message: 'Erroneous response' },
-        },
-      }
-      ;(resetCardStage as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
+      server.use(
+        http.post('*/user/cards/reset-stage', () =>
+          HttpResponse.json(
+            { status: 'failedTransaction', message: 'Erroneous response' },
+            { status: 400 }
+          )
+        )
+      )
 
       let showModal = true
       let onClose = () => {
@@ -206,12 +180,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when response is 500 and display error message', async () => {
-      const error = {
-        response: { status: 500, data: { status: 'internalServerError', message: 'Server error' } },
-      }
-      ;(resetCardStage as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
+      server.use(
+        http.post('*/user/cards/reset-stage', () =>
+          HttpResponse.json(
+            { status: 'internalServerError', message: 'Server error' },
+            { status: 500 }
+          )
+        )
+      )
       let showModal = true
       let onClose = () => {
         showModal = false
@@ -243,9 +219,7 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when error is thrown with no response', async () => {
-      ;(resetCardStage as jest.Mock).mockImplementation(() => {
-        return Promise.reject({ status: 500, message: 'Error thrown and caught.' })
-      })
+      server.use(http.post('*/user/cards/reset-stage', () => HttpResponse.error()))
 
       let showModal = true
       let onClose = () => {
@@ -283,14 +257,8 @@ describe('Manage Card Popup', () => {
       activities: [{ ...mockActivity, cards: [mockUserCard] }],
     }
 
-    beforeEach(() => {
-      jest.useFakeTimers()
-      jest.setSystemTime(new Date('2/3/2024'))
-    })
-
     afterEach(() => {
       jest.clearAllMocks()
-      jest.useRealTimers()
     })
 
     it('should render popup to submit form for review', async () => {
@@ -321,14 +289,7 @@ describe('Manage Card Popup', () => {
       )
     })
 
-    it('should invoke requestCardReview controller when form is submitted', async () => {
-      ;(requestCardReview as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({ status: 200, data: { message: null, details: {} } })
-      })
-      ;(editCardStage as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({ status: 200, data: { message: null, details: mockUserCard } })
-      })
-
+    it('should show success toast after requesting review', async () => {
       let showModal
       let onClose = () => {
         showModal = false
@@ -348,34 +309,17 @@ describe('Manage Card Popup', () => {
       )
 
       const requestReviewBtn = await screen.findByTestId('submit-review-btn')
-      const resetCardStageDTO = {
-        id: mockUserCard.cardId,
-        teacherId: mockUser.userId,
-        student: {
-          id: mockStudent.userId,
-          fullName: `${mockStudent.firstName} ${mockStudent.lastName}`,
-          email: mockStudent.email,
-        },
-      }
 
       await act(async () => {
         await fireEvent.click(requestReviewBtn)
       })
 
-      await expect(requestCardReview).toHaveBeenCalledWith(resetCardStageDTO)
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('Request for review successfully sent.')
+      })
     })
 
     it('should close popup when response is successful and display success message, then reset message when form in focus', async () => {
-      ;(requestCardReview as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 200,
-          data: { message: 'Successfully request review for card.', details: {} },
-        })
-      })
-      ;(editCardStage as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({ status: 200, data: { message: null, details: mockUserCard } })
-      })
-
       let showModal
       let onClose = () => {
         showModal = false
@@ -406,15 +350,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when response is not 200 or 500 and display error message', async () => {
-      const error = {
-        response: {
-          status: 400,
-          data: { status: 'failedTransaction', message: 'Erroneous response' },
-        },
-      }
-      ;(requestCardReview as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
+      server.use(
+        http.post('*/user/cards/request-review', () =>
+          HttpResponse.json(
+            { status: 'failedTransaction', message: 'Erroneous response' },
+            { status: 400 }
+          )
+        )
+      )
 
       let showModal = true
       let onClose = () => {
@@ -445,12 +388,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when response is 500 and display error message', async () => {
-      const error = {
-        response: { status: 500, data: { status: 'internalServerError', message: 'Server error' } },
-      }
-      ;(requestCardReview as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
+      server.use(
+        http.post('*/user/cards/request-review', () =>
+          HttpResponse.json(
+            { status: 'internalServerError', message: 'Server error' },
+            { status: 500 }
+          )
+        )
+      )
       let showModal = true
       let onClose = () => {
         showModal = false
@@ -482,9 +427,7 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when error is thrown with no response', async () => {
-      ;(requestCardReview as jest.Mock).mockImplementation(() => {
-        return Promise.reject({ status: 500, message: 'Error thrown and caught.' })
-      })
+      server.use(http.post('*/user/cards/request-review', () => HttpResponse.error()))
 
       let showModal = true
       let onClose = () => {
@@ -563,21 +506,12 @@ describe('Manage Card Popup', () => {
       ],
     }
 
-    beforeEach(() => {
-      jest.useFakeTimers()
-      jest.setSystemTime(new Date('2/3/2024'))
-    })
-
     afterEach(() => {
       jest.clearAllMocks()
-      jest.useRealTimers()
     })
 
-    it('should invoke editAnyCardAttr controller when form is submitted', async () => {
+    it('should show success toast after overriding card stage', async () => {
       expect(myUser.activities[0].cards[0].stage).toEqual('7')
-      ;(editAnyCardAttr as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({ status: 200, data: { message: null, details: mockUserCard } })
-      })
 
       let showModal
       let onClose = () => {
@@ -606,31 +540,17 @@ describe('Manage Card Popup', () => {
 
       expect(stageManagementBlock).toHaveTextContent('Override current stage: 7')
 
-      const overrideStageDTO = {
-        userId: mockUser.userId,
-        activity: 'Quran',
-        cardId: mockUserCard.cardId,
-        editData: {
-          stage: '30',
-        },
-      }
-
       await act(async () => {
         fireEvent.change(overrideStageForm, { target: { value: '30' } })
         await fireEvent.click(overrideStageBtn)
       })
 
-      await expect(editAnyCardAttr).toHaveBeenCalledWith(overrideStageDTO)
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('Successfully overrode status.')
+      })
     })
 
     it('should close popup when response is successful and display success message, then reset message when form in focus', async () => {
-      ;(editAnyCardAttr as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 200,
-          data: { message: 'Successfully overrode status.', details: mockUserCard },
-        })
-      })
-
       let showModal
       let onClose = () => {
         showModal = false
@@ -666,15 +586,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when response is not 200 or 500 and display error message', async () => {
-      const error = {
-        response: {
-          status: 400,
-          data: { status: 'failedTransaction', message: 'Erroneous response' },
-        },
-      }
-      ;(editAnyCardAttr as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
+      server.use(
+        http.post('*/user/cards/edit', () =>
+          HttpResponse.json(
+            { status: 'failedTransaction', message: 'Erroneous response' },
+            { status: 400 }
+          )
+        )
+      )
 
       let showModal = true
       let onClose = () => {
@@ -708,12 +627,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when response is 500 and display error message', async () => {
-      const error = {
-        response: { status: 500, data: { status: 'internalServerError', message: 'Server error' } },
-      }
-      ;(editAnyCardAttr as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
+      server.use(
+        http.post('*/user/cards/edit', () =>
+          HttpResponse.json(
+            { status: 'internalServerError', message: 'Server error' },
+            { status: 500 }
+          )
+        )
+      )
       let showModal = true
       let onClose = () => {
         showModal = false
@@ -748,9 +669,7 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when error is thrown with no response', async () => {
-      ;(editAnyCardAttr as jest.Mock).mockImplementation(() => {
-        return Promise.reject({ status: 500, message: 'Error thrown and caught.' })
-      })
+      server.use(http.post('*/user/cards/edit', () => HttpResponse.error()))
 
       let showModal = true
       let onClose = () => {
@@ -795,21 +714,11 @@ describe('Manage Card Popup', () => {
       ],
     }
 
-    beforeEach(() => {
-      jest.useFakeTimers()
-      jest.setSystemTime(new Date('2/3/2024'))
-    })
-
     afterEach(() => {
       jest.clearAllMocks()
-      jest.useRealTimers()
     })
 
-    it('should invoke editCardStage controller when promote form is submitted', async () => {
-      ;(editCardStage as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({ status: 200, data: { message: null, details: mockUserCard } })
-      })
-
+    it('should show success toast after promoting stage', async () => {
       let showModal
       let onClose = () => {
         showModal = false
@@ -833,28 +742,16 @@ describe('Manage Card Popup', () => {
 
       const promoteStageBtn = await screen.findByTestId('promote-stage-btn')
 
-      const promoteStageDTO = {
-        userId: mockUser.userId,
-        activity: 'Quran',
-        cardId: mockUserCard.cardId,
-        editData: {
-          stage: '7',
-          promote: true,
-        },
-      }
-
       await act(async () => {
         await fireEvent.click(promoteStageBtn)
       })
 
-      await expect(editCardStage).toHaveBeenCalledWith(promoteStageDTO)
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('Successfully edited status.')
+      })
     })
 
-    it('should invoke editCardStage controller when demote form is submitted', async () => {
-      ;(editCardStage as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({ status: 200, data: { message: null, details: mockUserCard } })
-      })
-
+    it('should show success toast after demoting stage', async () => {
       let showModal
       let onClose = () => {
         showModal = false
@@ -878,31 +775,16 @@ describe('Manage Card Popup', () => {
 
       const demoteStageBtn = await screen.findByTestId('demote-stage-btn')
 
-      const demoteStageDTO = {
-        userId: mockUser.userId,
-        activity: 'Quran',
-        cardId: mockUserCard.cardId,
-        editData: {
-          stage: '7',
-          promote: false,
-        },
-      }
-
       await act(async () => {
         await fireEvent.click(demoteStageBtn)
       })
 
-      await expect(editCardStage).toHaveBeenCalledWith(demoteStageDTO)
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('Successfully edited status.')
+      })
     })
 
     it('should close popup when response is successful and display success message, then reset message when form in focus', async () => {
-      ;(editCardStage as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 200,
-          data: { message: 'Successfully edited status.', details: mockUserCard },
-        })
-      })
-
       let showModal
       let onClose = () => {
         showModal = false
@@ -936,15 +818,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when response is not 200 or 500 and display error message', async () => {
-      const error = {
-        response: {
-          status: 400,
-          data: { status: 'failedTransaction', message: 'Erroneous response' },
-        },
-      }
-      ;(editCardStage as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
+      server.use(
+        http.post('*/user/cards/edit-stage', () =>
+          HttpResponse.json(
+            { status: 'failedTransaction', message: 'Erroneous response' },
+            { status: 400 }
+          )
+        )
+      )
 
       let showModal = true
       let onClose = () => {
@@ -978,12 +859,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when response is 500 and display error message', async () => {
-      const error = {
-        response: { status: 500, data: { status: 'internalServerError', message: 'Server error' } },
-      }
-      ;(editCardStage as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
+      server.use(
+        http.post('*/user/cards/edit-stage', () =>
+          HttpResponse.json(
+            { status: 'internalServerError', message: 'Server error' },
+            { status: 500 }
+          )
+        )
+      )
       let showModal = true
       let onClose = () => {
         showModal = false
@@ -1018,9 +901,7 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when error is thrown with no response', async () => {
-      ;(editCardStage as jest.Mock).mockImplementation(() => {
-        return Promise.reject({ status: 500, message: 'Error thrown and caught.' })
-      })
+      server.use(http.post('*/user/cards/edit-stage', () => HttpResponse.error()))
 
       let showModal = true
       let onClose = () => {
@@ -1057,21 +938,11 @@ describe('Manage Card Popup', () => {
   describe('Remove card', () => {
     const myUser = { ...mockUser, activities: [{ ...mockActivity, cards: [mockUserCard] }] }
 
-    beforeEach(() => {
-      jest.useFakeTimers()
-      jest.setSystemTime(new Date('2/3/2024'))
-    })
-
     afterEach(() => {
       jest.clearAllMocks()
-      jest.useRealTimers()
     })
 
-    it('should invoke deleteCard controller when form is submitted', async () => {
-      ;(deleteCard as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({ status: 200, data: { message: null, details: {} } })
-      })
-
+    it('should show success toast after deleting card', async () => {
       let showModal
       let onClose = () => {
         showModal = false
@@ -1091,29 +962,17 @@ describe('Manage Card Popup', () => {
       )
 
       const deleteCardBtn = await screen.findByTestId('delete-card-btn')
-      const deleteCardDTO = [
-        {
-          userId: mockUser.userId,
-          activity: mockActivity.name,
-          cardId: mockUserCard.cardId,
-        },
-      ]
 
       await act(async () => {
         await fireEvent.click(deleteCardBtn)
       })
 
-      await expect(deleteCard).toHaveBeenCalledWith(deleteCardDTO)
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('Successfully removed card')
+      })
     })
 
     it('should close popup when response is successful and display success message, then reset message when form in focus', async () => {
-      ;(deleteCard as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 200,
-          data: { message: 'Successfully removed card.', details: {} },
-        })
-      })
-
       let showModal
       let onClose = () => {
         showModal = false
@@ -1144,15 +1003,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when response is not 200 or 500 and display error message', async () => {
-      const error = {
-        response: {
-          status: 400,
-          data: { status: 'failedTransaction', message: 'Erroneous response' },
-        },
-      }
-      ;(deleteCard as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
+      server.use(
+        http.post('*/user/cards/delete', () =>
+          HttpResponse.json(
+            { status: 'failedTransaction', message: 'Erroneous response' },
+            { status: 400 }
+          )
+        )
+      )
 
       let showModal = true
       let onClose = () => {
@@ -1183,12 +1041,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when response is 500 and display error message', async () => {
-      const error = {
-        response: { status: 500, data: { status: 'internalServerError', message: 'Server error' } },
-      }
-      ;(deleteCard as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
+      server.use(
+        http.post('*/user/cards/delete', () =>
+          HttpResponse.json(
+            { status: 'internalServerError', message: 'Server error' },
+            { status: 500 }
+          )
+        )
+      )
       let showModal = true
       let onClose = () => {
         showModal = false
@@ -1220,9 +1080,7 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when error is thrown with no response', async () => {
-      ;(deleteCard as jest.Mock).mockImplementation(() => {
-        return Promise.reject({ status: 500, message: 'Error thrown and caught.' })
-      })
+      server.use(http.post('*/user/cards/delete', () => HttpResponse.error()))
 
       let showModal = true
       let onClose = () => {
@@ -1256,21 +1114,11 @@ describe('Manage Card Popup', () => {
   describe('Activate card', () => {
     const myUser = { ...mockUser, activities: [{ ...mockActivity, cards: [mockUserCard] }] }
 
-    beforeEach(() => {
-      jest.useFakeTimers()
-      jest.setSystemTime(new Date('2/3/2024'))
-    })
-
     afterEach(() => {
       jest.clearAllMocks()
-      jest.useRealTimers()
     })
 
-    it('should invoke activateCard controller when form is submitted', async () => {
-      ;(activateCard as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({ status: 200, data: { message: null, details: mockUserCard } })
-      })
-
+    it('should show success toast after activating card', async () => {
       let showModal
       let onClose = () => {
         showModal = false
@@ -1290,27 +1138,17 @@ describe('Manage Card Popup', () => {
       )
 
       const activateCardBtn = await screen.findByTestId('activate-card-btn')
-      const activateCardDTO = {
-        userId: mockUser.userId,
-        activity: mockActivity.name,
-        cardId: mockUserCard.cardId,
-      }
 
       await act(async () => {
         await fireEvent.click(activateCardBtn)
       })
 
-      await expect(activateCard).toHaveBeenCalledWith(activateCardDTO)
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('Successfully activated card')
+      })
     })
 
     it('should close popup when response is successful and display success message, then reset message when form in focus', async () => {
-      ;(activateCard as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 200,
-          data: { message: 'Successfully activated card.', details: {} },
-        })
-      })
-
       let showModal
       let onClose = () => {
         showModal = false
@@ -1341,15 +1179,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when response is not 200 or 500 and display error message', async () => {
-      const error = {
-        response: {
-          status: 400,
-          data: { status: 'failedTransaction', message: 'Erroneous response' },
-        },
-      }
-      ;(activateCard as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
+      server.use(
+        http.post('*/user/cards/activate', () =>
+          HttpResponse.json(
+            { status: 'failedTransaction', message: 'Erroneous response' },
+            { status: 400 }
+          )
+        )
+      )
 
       let showModal = true
       let onClose = () => {
@@ -1380,12 +1217,14 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when response is 500 and display error message', async () => {
-      const error = {
-        response: { status: 500, data: { status: 'internalServerError', message: 'Server error' } },
-      }
-      ;(activateCard as jest.Mock).mockImplementation(() => {
-        return Promise.reject(error)
-      })
+      server.use(
+        http.post('*/user/cards/activate', () =>
+          HttpResponse.json(
+            { status: 'internalServerError', message: 'Server error' },
+            { status: 500 }
+          )
+        )
+      )
       let showModal = true
       let onClose = () => {
         showModal = false
@@ -1417,9 +1256,7 @@ describe('Manage Card Popup', () => {
     })
 
     it('should not close popup when error is thrown with no response', async () => {
-      ;(activateCard as jest.Mock).mockImplementation(() => {
-        return Promise.reject({ status: 500, message: 'Error thrown and caught.' })
-      })
+      server.use(http.post('*/user/cards/activate', () => HttpResponse.error()))
 
       let showModal = true
       let onClose = () => {
@@ -1461,21 +1298,11 @@ describe('Manage Card Popup', () => {
       ],
     }
     describe('Override stage', () => {
-      beforeEach(() => {
-        jest.useFakeTimers()
-        jest.setSystemTime(new Date('2/3/2024'))
-      })
-
       afterEach(() => {
         jest.clearAllMocks()
-        jest.useRealTimers()
       })
 
-      it('should invoke editAnyCardAttr controller when form is submitted', async () => {
-        ;(editAnyCardAttr as jest.Mock).mockImplementationOnce(() => {
-          return Promise.resolve({ status: 200, data: { message: null, details: mockUserCard } })
-        })
-
+      it('should show success toast after overriding student card stage', async () => {
         let showModal
         let onClose = () => {
           showModal = false
@@ -1503,21 +1330,14 @@ describe('Manage Card Popup', () => {
 
         expect(stageManagementBlock).toHaveTextContent('Override current stage: 7')
 
-        const overrideStageDTO = {
-          userId: mockStudent.userId,
-          activity: 'Quran',
-          cardId: mockUserCard.cardId,
-          editData: {
-            stage: '30',
-          },
-        }
-
         await act(async () => {
           fireEvent.change(overrideStageForm, { target: { value: '30' } })
           await fireEvent.click(overrideStageBtn)
         })
 
-        await expect(editAnyCardAttr).toHaveBeenCalledWith(overrideStageDTO)
+        await waitFor(() => {
+          expect(toast.success).toHaveBeenCalledWith('Successfully overrode status.')
+        })
       })
     })
   })
@@ -1529,24 +1349,11 @@ describe('Manage Card Popup', () => {
       cardId: `${btoa('surah-113-name-Falaq-juz-30')}`,
     }
 
-    beforeEach(() => {
-      jest.useFakeTimers()
-      jest.setSystemTime(new Date('2/3/2024'))
-    })
-
     afterEach(() => {
       jest.clearAllMocks()
-      jest.useRealTimers()
     })
 
     it('should clear status message when popup reopens with a different card', async () => {
-      ;(resetCardStage as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({
-          status: 200,
-          data: { message: 'Successfully reset card.', details: {} },
-        })
-      })
-
       const onClose = jest.fn()
 
       const { rerender } = render(
@@ -1594,27 +1401,11 @@ describe('Manage Card Popup', () => {
   describe('Popup closes after successful card mutation', () => {
     const myUser = { ...mockUser, activities: [{ ...mockActivity, cards: [mockUserCard] }] }
 
-    beforeEach(() => {
-      jest.useFakeTimers()
-      jest.setSystemTime(new Date('2/3/2024'))
-    })
-
     afterEach(() => {
       jest.clearAllMocks()
-      jest.useRealTimers()
     })
 
     it('should call onClose after successful card activation', async () => {
-      ;(activateCard as jest.Mock).mockImplementationOnce(() => {
-        return Promise.resolve({ status: 200, data: { message: null, details: mockUserCard } })
-      })
-      ;(findUser as jest.Mock).mockImplementation(() => {
-        return Promise.resolve({
-          status: 200,
-          data: { details: { student: myUser } },
-        })
-      })
-
       const onClose = jest.fn()
 
       render(


### PR DESCRIPTION
…to MSW v2

## Summary by Sourcery

Refactor UI tests to use MSW-based network mocking and toast-based success assertions instead of directly mocking controller functions and system time.

Enhancements:
- Update Manage Card popup, Add Quran card form, and Students list tests to assert user-visible success and error messaging (toasts and inline errors) rather than controller invocation details.
- Simplify tests by removing manual fake timer usage and reliance on fixed system dates where not needed.
- Align Students list navigation tests with cached vs fetched student data behavior while decoupling them from direct controller mocks.
- Remove direct mocking of the controller layer from Cards list tests to support the new MSW-based testing approach.

Tests:
- Migrate various card management, card creation, and student lookup tests from jest.mock-based controller mocking to MSW v2 HTTP handlers for both success and error scenarios.