### PR TITLE
refactor(3): derive breadcrumbs in useMemo, migrate <a> to <Link>

### DIFF
--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -5,7 +5,7 @@ import { ChevronRightIcon, HomeIcon } from '@heroicons/react/24/solid'
 import { useParams, usePathname } from 'next/navigation'
 import { useMemo } from 'react'
 
-type Crumb = { label: string; href: string | null }
+type Crumb = { label: string; href?: string }
 
 export default function Breadcrumbs() {
   const params = useParams()
@@ -15,6 +15,7 @@ export default function Breadcrumbs() {
   const pathName = usePathname()
 
   const breadcrumbs = useMemo<Crumb[]>(() => {
+    if (!pathName) return []
     const segments = pathName.split('/')
     const crumbs: Crumb[] = []
 
@@ -28,16 +29,16 @@ export default function Breadcrumbs() {
           break
         case 3:
           if (segments[2] === 'activities') {
-            crumbs.push({ label: pathCurrentActivity, href: null })
+            crumbs.push({ label: pathCurrentActivity })
           } else if (segments[2] === 'students') {
             if (segments.length === 4) {
-              crumbs.push({ label: pathStudent, href: null })
+              crumbs.push({ label: pathStudent })
             } else if (segments.length > 4) {
               crumbs.push({
                 label: `All ${pathStudent}'s Activities`,
                 href: `/${pathUsername}/students/${pathStudent}`,
               })
-              crumbs.push({ label: pathCurrentActivity, href: null })
+              crumbs.push({ label: pathCurrentActivity })
             }
           }
           break
@@ -69,15 +70,7 @@ export default function Breadcrumbs() {
                 strokeLinejoin="round"
               />
             )}
-            {crumb.href === null ? (
-              <span
-                data-testid={`breadcrumbs-${crumb.label}`}
-                aria-current="page"
-                className="ms-1 text-sm font-medium text-gray-500 md:ms-2 dark:text-gray-400"
-              >
-                {formatBreadcrumbText(crumb.label)}
-              </span>
-            ) : (
+            {crumb.href ? (
               <Link
                 data-testid={`breadcrumbs-${crumb.label}`}
                 href={crumb.href}
@@ -92,6 +85,14 @@ export default function Breadcrumbs() {
                 )}
                 {formatBreadcrumbText(crumb.label)}
               </Link>
+            ) : (
+              <span
+                data-testid={`breadcrumbs-${crumb.label}`}
+                aria-current="page"
+                className="ms-1 text-sm font-medium text-gray-500 md:ms-2 dark:text-gray-400"
+              >
+                {formatBreadcrumbText(crumb.label)}
+              </span>
             )}
           </li>
         ))}

--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -1,38 +1,43 @@
 'use client'
 
+import Link from 'next/link'
 import { ChevronRightIcon, HomeIcon } from '@heroicons/react/24/solid'
 import { useParams, usePathname } from 'next/navigation'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
+
+type Crumb = { label: string; href: string | null }
 
 export default function Breadcrumbs() {
-  const pathUsername = useParams().username as string
-  const pathCurrentActivity = useParams().activity as string
-  const pathStudent = useParams().student as string
+  const params = useParams()
+  const pathUsername = params.username as string
+  const pathCurrentActivity = params.activity as string
+  const pathStudent = params.student as string
   const pathName = usePathname()
-  const pathSegments = useMemo(() => pathName?.split('/'), [pathName])
 
-  const [breadcrumbs, updateBreadcrumbs] = useState<any[]>([])
+  const breadcrumbs = useMemo<Crumb[]>(() => {
+    const segments = pathName.split('/')
+    const crumbs: Crumb[] = []
 
-  useEffect(() => {
-    const breadcrumbsDict: Record<string, string | null> = {}
-    pathSegments.forEach((_seg, idx) => {
+    segments.forEach((_seg, idx) => {
       switch (idx) {
         case 1:
-          breadcrumbsDict['Home'] = '/home'
+          crumbs.push({ label: 'Home', href: '/home' })
           break
         case 2:
-          breadcrumbsDict['Dashboard'] = `/${pathUsername}`
+          crumbs.push({ label: 'Dashboard', href: `/${pathUsername}` })
           break
         case 3:
-          if (pathSegments[2] === 'activities') {
-            breadcrumbsDict[`${pathCurrentActivity}`] = null
-          } else if (pathSegments[2] === 'students') {
-            if (pathSegments.length === 4) {
-              breadcrumbsDict[`${pathStudent}`] = null
-            } else if (pathSegments.length > 4) {
-              breadcrumbsDict[`All ${pathStudent}'s Activities`] =
-                `/${pathUsername}/students/${pathStudent}`
-              breadcrumbsDict[`${pathCurrentActivity}`] = null
+          if (segments[2] === 'activities') {
+            crumbs.push({ label: pathCurrentActivity, href: null })
+          } else if (segments[2] === 'students') {
+            if (segments.length === 4) {
+              crumbs.push({ label: pathStudent, href: null })
+            } else if (segments.length > 4) {
+              crumbs.push({
+                label: `All ${pathStudent}'s Activities`,
+                href: `/${pathUsername}/students/${pathStudent}`,
+              })
+              crumbs.push({ label: pathCurrentActivity, href: null })
             }
           }
           break
@@ -41,64 +46,56 @@ export default function Breadcrumbs() {
       }
     })
 
-    updateBreadcrumbs(Object.entries(breadcrumbsDict))
-  }, [pathSegments, pathUsername, pathCurrentActivity, pathStudent])
+    return crumbs
+  }, [pathName, pathUsername, pathCurrentActivity, pathStudent])
 
   function formatBreadcrumbText(text: string) {
     return text.split('-').join(' ')
   }
 
   return (
-    <>
-      <nav className="flex" aria-label="Breadcrumb">
-        <ol className="inline-flex items-center space-x-1 md:space-x-2 rtl:space-x-reverse">
-          {breadcrumbs.map((crumb, i) => (
-            <li className="inline-flex items-center" key={`${crumb}-${i}`}>
-              {crumb[0] === 'Home' && (
-                <a
-                  data-testid={`breadcrumbs-${crumb[0]}`}
-                  href={`${crumb[1]}`}
-                  className="inline-flex items-center text-sm font-medium text-gray-700 hover:text-blue-600 dark:text-gray-400 dark:hover:text-white"
-                >
+    <nav className="flex" aria-label="Breadcrumb">
+      <ol className="inline-flex items-center space-x-1 md:space-x-2 rtl:space-x-reverse">
+        {breadcrumbs.map((crumb, i) => (
+          <li className="inline-flex items-center" key={`${crumb.label}-${i}`}>
+            {i > 0 && (
+              <ChevronRightIcon
+                className="rtl:rotate-180 w-4 h-4 text-gray-400 mx-1"
+                strokeWidth={2}
+                aria-hidden="true"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            )}
+            {crumb.href === null ? (
+              <span
+                data-testid={`breadcrumbs-${crumb.label}`}
+                aria-current="page"
+                className="ms-1 text-sm font-medium text-gray-500 md:ms-2 dark:text-gray-400"
+              >
+                {formatBreadcrumbText(crumb.label)}
+              </span>
+            ) : (
+              <Link
+                data-testid={`breadcrumbs-${crumb.label}`}
+                href={crumb.href}
+                className={
+                  crumb.label === 'Home'
+                    ? 'inline-flex items-center text-sm font-medium text-gray-700 hover:text-blue-600 dark:text-gray-400 dark:hover:text-white'
+                    : 'ms-1 text-sm font-medium text-gray-700 hover:text-blue-600 md:ms-2 dark:text-gray-400 dark:hover:text-white'
+                }
+              >
+                {crumb.label === 'Home' && (
                   <HomeIcon className="w-4 h-4 me-2.5" aria-hidden="true" fill="currentColor" />
-                  {formatBreadcrumbText(crumb[0])}
-                </a>
-              )}
-              {crumb[0] !== 'Home' && (
-                <>
-                  <ChevronRightIcon
-                    className="rtl:rotate-180 w-4 h-4 text-gray-400 mx-1"
-                    strokeWidth={2}
-                    aria-hidden="true"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  {crumb[1] === null && (
-                    <span
-                      data-testid={`breadcrumbs-${crumb[0]}`}
-                      className="ms-1 text-sm font-medium text-gray-500 md:ms-2 dark:text-gray-400"
-                    >
-                      {formatBreadcrumbText(crumb[0])}
-                    </span>
-                  )}
-
-                  {crumb[1] !== null && (
-                    <a
-                      data-testid={`breadcrumbs-${crumb[0]}`}
-                      href={`${crumb[1]}`}
-                      className="ms-1 text-sm font-medium text-gray-700 hover:text-blue-600 md:ms-2 dark:text-gray-400 dark:hover:text-white"
-                    >
-                      {formatBreadcrumbText(crumb[0])}
-                    </a>
-                  )}
-                </>
-              )}
-            </li>
-          ))}
-        </ol>
-      </nav>
-    </>
+                )}
+                {formatBreadcrumbText(crumb.label)}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
   )
 }

--- a/src/specs/components/breadcrumbs.test.tsx
+++ b/src/specs/components/breadcrumbs.test.tsx
@@ -33,6 +33,7 @@ describe('Breadcrumbs', () => {
       const breadcrumbsHome = await screen.findByTestId('breadcrumbs-Home')
       expect(breadcrumbsHome).toBeInTheDocument()
       expect(breadcrumbsHome).toHaveTextContent('Home')
+      expect(breadcrumbsHome).not.toHaveAttribute('aria-current')
 
       breadcrumbsHome.addEventListener('click', (e) => {
         e.preventDefault()
@@ -62,6 +63,8 @@ describe('Breadcrumbs', () => {
       expect(breadcrumbsDashboard).toBeInTheDocument()
 
       expect(breadcrumbsDashboard).toHaveTextContent('Dashboard')
+      expect(breadcrumbsHome).not.toHaveAttribute('aria-current')
+      expect(breadcrumbsDashboard).not.toHaveAttribute('aria-current')
 
       breadcrumbsDashboard.addEventListener('click', (e) => {
         e.preventDefault()
@@ -96,6 +99,8 @@ describe('Breadcrumbs', () => {
       expect(breadcrumbsActivity).toHaveTextContent('Arabic Language')
       expect(breadcrumbsActivity).not.toHaveAttribute('href')
       expect(breadcrumbsActivity).toHaveAttribute('aria-current', 'page')
+      expect(breadcrumbsHome).not.toHaveAttribute('aria-current')
+      expect(breadcrumbsDashboard).not.toHaveAttribute('aria-current')
     })
   })
   describe('Student', () => {
@@ -117,6 +122,8 @@ describe('Breadcrumbs', () => {
         expect(breadcrumbsStudent).toHaveTextContent('Yusuf Spencer')
         expect(breadcrumbsStudent).not.toHaveAttribute('href')
         expect(breadcrumbsStudent).toHaveAttribute('aria-current', 'page')
+        expect(breadcrumbsHome).not.toHaveAttribute('aria-current')
+        expect(breadcrumbsDashboard).not.toHaveAttribute('aria-current')
       })
     })
 
@@ -147,6 +154,9 @@ describe('Breadcrumbs', () => {
 
         expect(breadcrumbsStudentActivity).not.toHaveAttribute('href')
         expect(breadcrumbsStudentActivity).toHaveAttribute('aria-current', 'page')
+        expect(breadcrumbsHome).not.toHaveAttribute('aria-current')
+        expect(breadcrumbsDashboard).not.toHaveAttribute('aria-current')
+        expect(breadcrumbsStudentActivities).not.toHaveAttribute('aria-current')
 
         breadcrumbsStudentActivities.addEventListener('click', (e) => {
           e.preventDefault()
@@ -160,6 +170,18 @@ describe('Breadcrumbs', () => {
           await fireEvent.click(breadcrumbsStudentActivities)
         })
       })
+    })
+  })
+
+  describe('Missing pathname', () => {
+    it('should render no breadcrumbs when usePathname returns null', () => {
+      jest
+        .spyOn(require('next/navigation'), 'usePathname')
+        .mockImplementation(() => null as unknown as string)
+      render(<Breadcrumbs />)
+
+      expect(screen.queryByTestId('breadcrumbs-Home')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('breadcrumbs-Dashboard')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/specs/components/breadcrumbs.test.tsx
+++ b/src/specs/components/breadcrumbs.test.tsx
@@ -95,6 +95,7 @@ describe('Breadcrumbs', () => {
 
       expect(breadcrumbsActivity).toHaveTextContent('Arabic Language')
       expect(breadcrumbsActivity).not.toHaveAttribute('href')
+      expect(breadcrumbsActivity).toHaveAttribute('aria-current', 'page')
     })
   })
   describe('Student', () => {
@@ -115,6 +116,7 @@ describe('Breadcrumbs', () => {
 
         expect(breadcrumbsStudent).toHaveTextContent('Yusuf Spencer')
         expect(breadcrumbsStudent).not.toHaveAttribute('href')
+        expect(breadcrumbsStudent).toHaveAttribute('aria-current', 'page')
       })
     })
 
@@ -144,6 +146,7 @@ describe('Breadcrumbs', () => {
         expect(breadcrumbsStudentActivity).toHaveTextContent('Arabic Language')
 
         expect(breadcrumbsStudentActivity).not.toHaveAttribute('href')
+        expect(breadcrumbsStudentActivity).toHaveAttribute('aria-current', 'page')
 
         breadcrumbsStudentActivities.addEventListener('click', (e) => {
           e.preventDefault()


### PR DESCRIPTION
## Summary by Sourcery

Refactor the breadcrumbs component to derive breadcrumb data via useMemo and use Next.js Link for navigable breadcrumb items while improving accessibility for the current page crumb.

Enhancements:
- Replace state and effect-based breadcrumb construction with a memoized breadcrumb list derived directly from the current path and route params.
- Unify breadcrumb rendering with a typed crumb model and conditional styling for home vs. other items.
- Switch breadcrumb anchor tags to Next.js Link components for client-side navigation.

Tests:
- Extend breadcrumbs tests to assert aria-current="page" on the active breadcrumb item for activities and students.